### PR TITLE
Fix Find My sidebar OCR parsing edge cases

### DIFF
--- a/cmd/findmy/main.go
+++ b/cmd/findmy/main.go
@@ -87,10 +87,7 @@ func runPeople(args []string) {
 	must(err)
 
 	sidebarRightPx, textColMinPx := pixelLayout(w, shot)
-	if !findmy.PeopleSidebarVisible(lines, sidebarRightPx) {
-		fmt.Fprintln(os.Stderr, "Find My People sidebar is not visible. Open the sidebar, select People, then re-run findmy.")
-		os.Exit(1)
-	}
+	must(findmy.RequireSidebarVisible(lines, sidebarRightPx))
 	people := findmy.ParsePeople(lines, sidebarRightPx, textColMinPx)
 
 	if opts.json {
@@ -132,10 +129,7 @@ func runPerson(args []string) {
 	must(err)
 
 	sidebarRightPx, textColMinPx := pixelLayout(w, shot)
-	if !findmy.PeopleSidebarVisible(lines, sidebarRightPx) {
-		fmt.Fprintln(os.Stderr, "Find My People sidebar is not visible. Open the sidebar, select People, then re-run findmy.")
-		os.Exit(1)
-	}
+	must(findmy.RequireSidebarVisible(lines, sidebarRightPx))
 	people := findmy.ParsePeople(lines, sidebarRightPx, textColMinPx)
 
 	var match *findmy.Person

--- a/cmd/findmy/main.go
+++ b/cmd/findmy/main.go
@@ -88,7 +88,7 @@ func runPeople(args []string) {
 
 	sidebarRightPx, textColMinPx := pixelLayout(w, shot)
 	if !findmy.PeopleSidebarVisible(lines, sidebarRightPx) {
-		fmt.Fprintln(os.Stderr, "error: Find My People sidebar is not visible; open the sidebar/People tab and re-run")
+		fmt.Fprintln(os.Stderr, "Find My People sidebar is not visible. Open the sidebar, select People, then re-run findmy.")
 		os.Exit(1)
 	}
 	people := findmy.ParsePeople(lines, sidebarRightPx, textColMinPx)
@@ -133,7 +133,7 @@ func runPerson(args []string) {
 
 	sidebarRightPx, textColMinPx := pixelLayout(w, shot)
 	if !findmy.PeopleSidebarVisible(lines, sidebarRightPx) {
-		fmt.Fprintln(os.Stderr, "error: Find My People sidebar is not visible; open the sidebar/People tab and re-run")
+		fmt.Fprintln(os.Stderr, "Find My People sidebar is not visible. Open the sidebar, select People, then re-run findmy.")
 		os.Exit(1)
 	}
 	people := findmy.ParsePeople(lines, sidebarRightPx, textColMinPx)

--- a/cmd/findmy/main.go
+++ b/cmd/findmy/main.go
@@ -87,6 +87,10 @@ func runPeople(args []string) {
 	must(err)
 
 	sidebarRightPx, textColMinPx := pixelLayout(w, shot)
+	if !findmy.PeopleSidebarVisible(lines, sidebarRightPx) {
+		fmt.Fprintln(os.Stderr, "error: Find My People sidebar is not visible; open the sidebar/People tab and re-run")
+		os.Exit(1)
+	}
 	people := findmy.ParsePeople(lines, sidebarRightPx, textColMinPx)
 
 	if opts.json {
@@ -128,6 +132,10 @@ func runPerson(args []string) {
 	must(err)
 
 	sidebarRightPx, textColMinPx := pixelLayout(w, shot)
+	if !findmy.PeopleSidebarVisible(lines, sidebarRightPx) {
+		fmt.Fprintln(os.Stderr, "error: Find My People sidebar is not visible; open the sidebar/People tab and re-run")
+		os.Exit(1)
+	}
 	people := findmy.ParsePeople(lines, sidebarRightPx, textColMinPx)
 
 	var match *findmy.Person
@@ -163,7 +171,6 @@ func runPerson(args []string) {
 	}
 	fmt.Println()
 }
-
 
 // pixelLayout returns the sidebar-right and name-column-left thresholds in
 // image pixels. The FindMy sidebar is ~340pt wide; the avatar column is

--- a/internal/findmy/findmy.go
+++ b/internal/findmy/findmy.go
@@ -238,14 +238,16 @@ func PreparePeople() (*Window, error) {
 // person names), then walk the remaining lines top-to-bottom.
 func ParsePeople(lines []TextLine, sidebarRightPx, textColMinPx int) []Person {
 	rows := make([]TextLine, 0, len(lines))
+	effectiveSidebarRightPx := detectSidebarRight(lines, sidebarRightPx)
+	rowStartY := detectPeopleRowStartY(lines, effectiveSidebarRightPx)
 	for _, l := range lines {
 		if strings.TrimSpace(l.Text) == "" {
 			continue
 		}
-		if l.X+l.Width/2 >= sidebarRightPx {
+		if l.X+l.Width/2 >= effectiveSidebarRightPx {
 			continue
 		}
-		if l.Y < 240 {
+		if l.Y < rowStartY {
 			continue
 		}
 		if l.X < textColMinPx {
@@ -266,7 +268,7 @@ func ParsePeople(lines []TextLine, sidebarRightPx, textColMinPx int) []Person {
 		"FaceTime": true, "Search": true, "+": true, "3D": true, "N": true,
 	}
 
-	var people []Person
+	people := make([]Person, 0)
 	var current *Person
 	for _, l := range rows {
 		txt := strings.TrimSpace(l.Text)
@@ -295,6 +297,57 @@ func ParsePeople(lines []TextLine, sidebarRightPx, textColMinPx int) []Person {
 // visual rows because of a long "City, ST • 2 min. ago" string. The
 // telltale: the previous row contains the " • " separator and the next row
 // is within ~35px below it and looks like a relative-time suffix.
+func detectSidebarRight(lines []TextLine, fallbackRightPx int) int {
+	maxTabRight := 0
+	for _, l := range lines {
+		txt := strings.TrimSpace(l.Text)
+		if txt != "People" && txt != "Devices" && txt != "Items" {
+			continue
+		}
+		if l.Y > 220 {
+			continue
+		}
+		if r := l.X + l.Width; r > maxTabRight {
+			maxTabRight = r
+		}
+	}
+	if maxTabRight == 0 {
+		return fallbackRightPx
+	}
+	// The segmented People/Devices/Items control sits inside the sidebar.
+	// Its right edge is a better observed boundary than a fixed scaled point
+	// width on compact Catalyst layouts where map labels start near x≈350px.
+	observed := maxTabRight + 40
+	if observed < fallbackRightPx {
+		return observed
+	}
+	return fallbackRightPx
+}
+
+func detectPeopleRowStartY(lines []TextLine, sidebarRightPx int) int {
+	const fallbackY = 120
+	bottom := 0
+	for _, l := range lines {
+		txt := strings.TrimSpace(l.Text)
+		if txt != "People" && txt != "Devices" && txt != "Items" {
+			continue
+		}
+		if l.X+l.Width/2 >= sidebarRightPx {
+			continue
+		}
+		if l.Y > 220 {
+			continue
+		}
+		if b := l.Y + l.Height; b > bottom {
+			bottom = b
+		}
+	}
+	if bottom == 0 {
+		return fallbackY
+	}
+	return bottom + 12
+}
+
 func mergeWrappedContinuations(rows []TextLine) []TextLine {
 	out := make([]TextLine, 0, len(rows))
 	for _, l := range rows {

--- a/internal/findmy/findmy.go
+++ b/internal/findmy/findmy.go
@@ -226,17 +226,13 @@ func PreparePeople() (*Window, error) {
 	return MainWindow()
 }
 
-// ParsePeople groups OCR lines from the People sidebar into Person records.
-// The sidebar layout (in image pixels) has three bands:
-//
-//	avatar:     x ≈   0–200   (round photo with initials — OCR noise lives here)
-//	text:       x ≈ 240–550   (name and location/staleness)
-//	distance:   x ≈ 580–700   ("1,971 mi" right-aligned to row top)
-//
-// We discard the avatar band entirely (it produces low-confidence fragments
-// like "Is" or "rk" from initials and shadows that otherwise get misread as
-// person names), then walk the remaining lines top-to-bottom.
-func PeopleSidebarVisible(lines []TextLine, sidebarRightPx int) bool {
+// RequireSidebarVisible returns an error when the People/Devices/Items
+// segmented control is missing from the OCR output, which happens when the
+// user has hidden the sidebar (View → Hide Sidebar, or the toggle button).
+// Without this gate ParsePeople sees only map content and yields nonsense
+// "people" rows pulled from map labels (place names, road names) rather
+// than friend names.
+func RequireSidebarVisible(lines []TextLine, sidebarRightPx int) error {
 	seenPeople := false
 	seenOtherTab := false
 	for _, l := range lines {
@@ -256,9 +252,27 @@ func PeopleSidebarVisible(lines []TextLine, sidebarRightPx int) bool {
 			seenOtherTab = true
 		}
 	}
-	return seenPeople && seenOtherTab
+	if seenPeople && seenOtherTab {
+		return nil
+	}
+	return fmt.Errorf("Find My People sidebar is not visible. Open the sidebar, select People, then re-run findmy")
 }
 
+// ParsePeople groups OCR lines from the People sidebar into Person records.
+// The sidebar layout (in image pixels) has three bands:
+//
+//	avatar:     x ≈   0–200   (round photo with initials — OCR noise lives here)
+//	text:       x ≈ 240–550   (name and location/staleness)
+//	distance:   x ≈ 580–700   ("1,971 mi" right-aligned to row top)
+//
+// We discard the avatar band entirely (it produces low-confidence fragments
+// like "Is" or "rk" from initials and shadows that otherwise get misread as
+// person names), then walk the remaining lines top-to-bottom. The sidebar's
+// right edge and the y-cutoff for the first row are derived from the OCR'd
+// People/Devices/Items tab-pill positions (see detectSidebarRight,
+// detectPeopleRowStartY) rather than fixed at scaled-point constants — the
+// dynamic bounds handle compact Catalyst layouts where map labels would
+// otherwise bleed into the fixed cutoff.
 func ParsePeople(lines []TextLine, sidebarRightPx, textColMinPx int) []Person {
 	rows := make([]TextLine, 0, len(lines))
 	effectiveSidebarRightPx := detectSidebarRight(lines, sidebarRightPx)
@@ -316,10 +330,11 @@ func ParsePeople(lines []TextLine, sidebarRightPx, textColMinPx int) []Person {
 	return people
 }
 
-// mergeWrappedContinuations folds OCR lines that Vision split across two
-// visual rows because of a long "City, ST • 2 min. ago" string. The
-// telltale: the previous row contains the " • " separator and the next row
-// is within ~35px below it and looks like a relative-time suffix.
+// detectSidebarRight returns the narrower of (the observed right edge of
+// the People/Devices/Items segmented control + 40px padding) and the
+// scaled-point fallback, so that on compact Catalyst layouts the cutoff
+// shrinks to exclude map labels that start near x≈350px. Returns the
+// fallback unchanged when no tab pill is OCR'd.
 func detectSidebarRight(lines []TextLine, fallbackRightPx int) int {
 	maxTabRight := 0
 	for _, l := range lines {
@@ -337,9 +352,6 @@ func detectSidebarRight(lines []TextLine, fallbackRightPx int) int {
 	if maxTabRight == 0 {
 		return fallbackRightPx
 	}
-	// The segmented People/Devices/Items control sits inside the sidebar.
-	// Its right edge is a better observed boundary than a fixed scaled point
-	// width on compact Catalyst layouts where map labels start near x≈350px.
 	observed := maxTabRight + 40
 	if observed < fallbackRightPx {
 		return observed
@@ -347,6 +359,11 @@ func detectSidebarRight(lines []TextLine, fallbackRightPx int) int {
 	return fallbackRightPx
 }
 
+// detectPeopleRowStartY returns the y-coordinate (image pixels) below
+// which actual people rows begin, computed as the bottom of the tab-pill
+// band plus 12px padding. The 120px fallback is effectively unreachable
+// because callers gate on RequireSidebarVisible — if there's no tab pill,
+// parsing is short-circuited before this is consulted.
 func detectPeopleRowStartY(lines []TextLine, sidebarRightPx int) int {
 	const fallbackY = 120
 	bottom := 0
@@ -371,6 +388,10 @@ func detectPeopleRowStartY(lines []TextLine, sidebarRightPx int) int {
 	return bottom + 12
 }
 
+// mergeWrappedContinuations folds OCR lines that Vision split across two
+// visual rows because of a long "City, ST • 2 min. ago" string. The
+// telltale: the previous row contains the " • " separator and the next row
+// is within ~35px below it and looks like a relative-time suffix.
 func mergeWrappedContinuations(rows []TextLine) []TextLine {
 	out := make([]TextLine, 0, len(rows))
 	for _, l := range rows {

--- a/internal/findmy/findmy.go
+++ b/internal/findmy/findmy.go
@@ -236,6 +236,29 @@ func PreparePeople() (*Window, error) {
 // We discard the avatar band entirely (it produces low-confidence fragments
 // like "Is" or "rk" from initials and shadows that otherwise get misread as
 // person names), then walk the remaining lines top-to-bottom.
+func PeopleSidebarVisible(lines []TextLine, sidebarRightPx int) bool {
+	seenPeople := false
+	seenOtherTab := false
+	for _, l := range lines {
+		txt := strings.TrimSpace(l.Text)
+		if txt != "People" && txt != "Devices" && txt != "Items" {
+			continue
+		}
+		if l.Y > 220 {
+			continue
+		}
+		if l.X+l.Width/2 >= sidebarRightPx {
+			continue
+		}
+		if txt == "People" {
+			seenPeople = true
+		} else {
+			seenOtherTab = true
+		}
+	}
+	return seenPeople && seenOtherTab
+}
+
 func ParsePeople(lines []TextLine, sidebarRightPx, textColMinPx int) []Person {
 	rows := make([]TextLine, 0, len(lines))
 	effectiveSidebarRightPx := detectSidebarRight(lines, sidebarRightPx)


### PR DESCRIPTION
## Summary
This PR fixes two related Find My sidebar parsing edge cases. The OCR capture path is unchanged: the CLI still activates FindMy.app, captures the window, runs the existing helper OCR, and receives the same `[]TextLine` data. The changes are limited to how that OCR output is validated and filtered before building `Person` records.

## Major fixes

### 1. Infer sidebar bounds from OCR anchors
Previously, `ParsePeople` relied on fixed scaled pixel thresholds for the sidebar right edge and the first people-row y-position. That worked for the normal layout, but compact Catalyst layouts can place map labels close enough to the sidebar that those labels fall inside the old fixed cutoff and get parsed as fake people.

This now uses the OCR-detected `People`, `Devices`, and `Items` segmented control as layout anchors:
- `detectSidebarRight` uses the observed right edge of those tabs, plus a small padding, while keeping the previous scaled-width value as a fallback.
- `detectPeopleRowStartY` starts parsing below the bottom of the tab control instead of using a hard-coded y cutoff.

That keeps the parser tied to what FindMy.app actually rendered instead of assuming one window layout.

### 2. Fail fast when the People sidebar is hidden
When the sidebar is hidden, the screenshot still contains OCR text from the map. Before this change, `ParsePeople` could interpret place names, road labels, or other map text as people because there was no guard confirming that the People sidebar was visible.

This adds `RequireSidebarVisible`, which looks for the `People` tab plus at least one sibling tab (`Devices` or `Items`) in the expected top-left sidebar area. Both `findmy people` and `findmy person` call this before parsing. If the tabs are not visible, the command now exits with an actionable message telling the user to open the sidebar and select People, rather than returning misleading person results.

## Validation
- `go test ./...`
- `go vet ./...`
- `git diff --check upstream/main...HEAD`
- `make build`

## Notes
I kept this as one PR because both changes address the same failure mode: preventing non-sidebar OCR text from being parsed as Find My people. The diff is small and contained to the CLI parsing path.