### PR TITLE
feat: add items verb (read FindMy.app Items tab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # findmy-cli
 
-Read your Find My people and device locations from the macOS FindMy.app via UI
+Read your Find My people, device, and item locations from the macOS FindMy.app via UI
 scraping. Apple does not expose a public API for Find My locations and the
 on-disk caches are encrypted with keychain-bound keys, so this tool drives the
-GUI: it activates FindMy.app, switches to the People or Devices tab,
+GUI: it activates FindMy.app, switches to the People, Devices, or Items tab,
 screenshots the window, and runs Vision OCR on the result.
 
 ## Why a Go CLI plus a Swift helper
@@ -76,6 +76,14 @@ findmy devices --json
 # Read one matching device.
 findmy device "Omar's iPhone"
 findmy device "Omar's iPhone" --json
+
+# List items in the sidebar.
+findmy items
+findmy items --json
+
+# Read one matching item.
+findmy item "AirPods Pro"
+findmy item "AirPods Pro" --json
 ```
 
 FindMy.app menu, tab, and sidebar labels are localized on non-English macOS

--- a/cmd/findmy/main.go
+++ b/cmd/findmy/main.go
@@ -25,6 +25,10 @@ func main() {
 		runDevices(os.Args[2:])
 	case "device":
 		runDevice(os.Args[2:])
+	case "items":
+		runItems(os.Args[2:])
+	case "item":
+		runItem(os.Args[2:])
 	case "-h", "--help", "help":
 		usage()
 	default:
@@ -41,6 +45,8 @@ Usage:
   findmy person  <name> [--json] [--keep]
   findmy devices [--json] [--keep]
   findmy device  <name> [--json] [--keep]
+  findmy items   [--json] [--keep]
+  findmy item    <name> [--json] [--keep]
 
 Flags:
   --json   emit JSON instead of a human table
@@ -157,6 +163,46 @@ func runDevices(args []string) {
 	}
 }
 
+func runItems(args []string) {
+	opts, _ := parseOpts(args)
+
+	w, err := findmy.PrepareItems()
+	must(err)
+	shot := filepath.Join(tmpDir(), "items.png")
+	must(findmy.Capture(w, shot))
+	defer cleanup(shot, opts.keep)
+
+	lines, err := findmy.OCR(shot)
+	must(err)
+
+	sidebarRightPx, textColMinPx := pixelLayout(w, shot)
+	must(findmy.RequireSidebarVisible(lines, sidebarRightPx, "Items"))
+	items := findmy.ParseItems(lines, sidebarRightPx, textColMinPx)
+
+	if opts.json {
+		emitJSON(items)
+		return
+	}
+	if len(items) == 0 {
+		fmt.Println("(no items found)")
+		return
+	}
+	sort.SliceStable(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+	for _, item := range items {
+		fmt.Printf("%s\n  %s", item.Name, item.Location)
+		if item.Staleness != "" {
+			fmt.Printf("  (%s)", item.Staleness)
+		}
+		if item.Distance != "" {
+			fmt.Printf("  [%s]", item.Distance)
+		}
+		if item.Battery != "" {
+			fmt.Printf("  {%s}", item.Battery)
+		}
+		fmt.Println()
+	}
+}
+
 func runDevice(args []string) {
 	opts, rest := parseOpts(args)
 	if len(rest) == 0 {
@@ -195,6 +241,64 @@ func runDevice(args []string) {
 	}
 	if match == nil {
 		fmt.Fprintf(os.Stderr, "no device matching %q in sidebar\n", target)
+		os.Exit(1)
+	}
+
+	if opts.json {
+		emitJSON(match)
+		return
+	}
+	fmt.Printf("%s\n  %s", match.Name, match.Location)
+	if match.Staleness != "" {
+		fmt.Printf("  (%s)", match.Staleness)
+	}
+	if match.Distance != "" {
+		fmt.Printf("  [%s]", match.Distance)
+	}
+	if match.Battery != "" {
+		fmt.Printf("  {%s}", match.Battery)
+	}
+	fmt.Println()
+}
+
+func runItem(args []string) {
+	opts, rest := parseOpts(args)
+	if len(rest) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: findmy item <name> [--json] [--keep]")
+		os.Exit(2)
+	}
+	target := strings.ToLower(strings.Join(rest, " "))
+
+	w, err := findmy.PrepareItems()
+	must(err)
+	shot := filepath.Join(tmpDir(), "items.png")
+	must(findmy.Capture(w, shot))
+	defer cleanup(shot, opts.keep)
+
+	lines, err := findmy.OCR(shot)
+	must(err)
+
+	sidebarRightPx, textColMinPx := pixelLayout(w, shot)
+	must(findmy.RequireSidebarVisible(lines, sidebarRightPx, "Items"))
+	items := findmy.ParseItems(lines, sidebarRightPx, textColMinPx)
+
+	var match *findmy.Item
+	for i := range items {
+		if strings.EqualFold(strings.TrimSpace(items[i].Name), target) {
+			match = &items[i]
+			break
+		}
+	}
+	if match == nil {
+		for i := range items {
+			if strings.Contains(strings.ToLower(items[i].Name), target) {
+				match = &items[i]
+				break
+			}
+		}
+	}
+	if match == nil {
+		fmt.Fprintf(os.Stderr, "no item matching %q in sidebar\n", target)
 		os.Exit(1)
 	}
 

--- a/internal/findmy/findmy.go
+++ b/internal/findmy/findmy.go
@@ -47,6 +47,14 @@ type Device struct {
 	Battery   string `json:"battery,omitempty"`
 }
 
+type Item struct {
+	Name      string `json:"name"`
+	Location  string `json:"location,omitempty"`
+	Staleness string `json:"staleness,omitempty"`
+	Distance  string `json:"distance,omitempty"`
+	Battery   string `json:"battery,omitempty"`
+}
+
 func helper() string {
 	if env := os.Getenv("FINDMY_HELPER"); env != "" {
 		return env
@@ -230,6 +238,12 @@ func PreparePeople() (*Window, error) {
 // phone" / "where are my AirPods" queries on his own iCloud.
 func PrepareDevices() (*Window, error) {
 	return prepareTab(GetAppStrings().DevicesTab)
+}
+
+// PrepareItems is the Items-tab mirror of PrepareDevices. AirTags, AirPods
+// cases, and third-party Find My network trackers live in this tab.
+func PrepareItems() (*Window, error) {
+	return prepareTab(GetAppStrings().ItemsTab)
 }
 
 func prepareTab(tab string) (*Window, error) {
@@ -533,6 +547,69 @@ func ParseDevices(lines []TextLine, sidebarRightPx, textColMinPx int) []Device {
 		current.Staleness = stale
 	}
 	return devices
+}
+
+// ParseItems groups OCR lines from the Items sidebar into Item records.
+// The layout mirrors Devices (icon column on left, text band middle, distance
+// right) and can also carry a battery indicator OCR'd as "82%" or similar.
+func ParseItems(lines []TextLine, sidebarRightPx, textColMinPx int) []Item {
+	rows := make([]TextLine, 0, len(lines))
+	effectiveSidebarRightPx := detectSidebarRight(lines, sidebarRightPx)
+	rowStartY := detectSidebarRowStartY(lines, effectiveSidebarRightPx)
+	for _, l := range lines {
+		if strings.TrimSpace(l.Text) == "" {
+			continue
+		}
+		if l.X+l.Width/2 >= effectiveSidebarRightPx {
+			continue
+		}
+		if l.Y < rowStartY {
+			continue
+		}
+		if l.X < textColMinPx {
+			continue
+		}
+		rows = append(rows, l)
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Y == rows[j].Y {
+			return rows[i].X < rows[j].X
+		}
+		return rows[i].Y < rows[j].Y
+	})
+	rows = mergeWrappedContinuations(rows)
+
+	skip := GetAppStrings().SkipWords()
+
+	items := make([]Item, 0)
+	var current *Item
+	for _, l := range rows {
+		txt := strings.TrimSpace(l.Text)
+		if skip[txt] {
+			continue
+		}
+		if isDistance(txt) {
+			if current != nil {
+				current.Distance = txt
+			}
+			continue
+		}
+		if isBattery(txt) {
+			if current != nil {
+				current.Battery = txt
+			}
+			continue
+		}
+		if current == nil || current.Location != "" {
+			items = append(items, Item{Name: txt})
+			current = &items[len(items)-1]
+			continue
+		}
+		loc, stale := splitLocationStaleness(txt)
+		current.Location = loc
+		current.Staleness = stale
+	}
+	return items
 }
 
 // isBattery recognizes FindMy.app's battery-indicator OCR fragments. The

--- a/internal/findmy/locale_test.go
+++ b/internal/findmy/locale_test.go
@@ -34,3 +34,16 @@ func TestSkipWordsIncludesLocalizedAndEnglishTabs(t *testing.T) {
 		}
 	}
 }
+
+func TestLookupStringsHasItemsTab(t *testing.T) {
+	tests := []string{"en", "fr-FR", "de-DE", "ja-JP", "pt-BR"}
+
+	for _, lang := range tests {
+		t.Run(lang, func(t *testing.T) {
+			got := lookupStrings(lang)
+			if got.ItemsTab == "" {
+				t.Fatalf("ItemsTab is empty")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`findmy items` and `findmy item <name>` now read the third sidebar tab of FindMy.app, the one that lists AirTags, AirPods cases, and other Find My network trackers paired through your iCloud. People (initial) and Devices (#1) were already covered; this rounds out the three-tab surface.

## Why this matters

The Items tab was already wired into the locale infrastructure: `AppStrings.ItemsTab` is populated for all 41 languages in `internal/findmy/locale.go`, and `sidebarTabText` in `internal/findmy/findmy.go` already classifies `"Items"` and `ls.ItemsTab` as a valid sidebar tab. The CLI just hadn't grown the corresponding verb. Anyone with AirTags or AirPods paired into Find My had no way to read them through this CLI.

## Demo

Simulated Demo:

![demo](https://files.catbox.moe/xkj2em.gif)

## Changes

- `cmd/findmy/main.go`: added `items` / `item` dispatch, usage banner, plus `runItems` and `runItem` (direct mirrors of `runDevices` / `runDevice`, including exact-then-substring match and `--json` / `--keep` flag handling)
- `internal/findmy/findmy.go`: added the `Item` struct, `PrepareItems`, and `ParseItems`. Layout matches Devices (avatar/text/distance bands, optional battery indicator), and `ParseItems` is a direct copy of `ParseDevices` with `[]Item` as the result type. Row-walking stays inline rather than generalizing across kinds, matching PR #1's style.
- `internal/findmy/locale_test.go`: spot-checks `ItemsTab` is populated for `en` / `fr-FR` / `de-DE` / `ja-JP` / `pt-BR`.
- `README.md`: usage section now lists the two new verbs.

## Testing

- `go test ./...` and `go vet ./...` pass.
- `make` rebuilds both binaries cleanly.
- Live-ran `./bin/findmy items --json` against a real iCloud account with active AirTags; got four rows including `{"name": "Shadow", "location": "Home", "staleness": "2 hr. ago"}` and no-location rows for tags that haven't pinged in a while. Sidebar gate (`RequireSidebarVisible`) still rejects when the Items tab is hidden.

Strictly additive; no existing code paths change.

AI was used for assistance.
