### PR TITLE
fix: drop 'This Mac' badge when parsing sidebar location

### DIFF
--- a/internal/findmy/findmy.go
+++ b/internal/findmy/findmy.go
@@ -463,11 +463,35 @@ func isDistance(s string) bool {
 	return false
 }
 
+// splitLocationStaleness parses a "<location> • <staleness>" sidebar line into
+// its two halves. One wrinkle: when the device is the Mac the user is
+// currently running on, FindMy.app puts a "This Mac" badge in the location
+// slot instead of an actual place ("This Mac • No location found"). The badge
+// is not a location, so when the left half is one of the known "This <device>"
+// labels we treat the right half as the location and drop the badge.
 func splitLocationStaleness(s string) (location, staleness string) {
-	if idx := strings.Index(s, "•"); idx >= 0 {
-		return strings.TrimSpace(s[:idx]), strings.TrimSpace(s[idx+len("•"):])
+	idx := strings.Index(s, "•")
+	if idx < 0 {
+		return s, ""
 	}
-	return s, ""
+	left := strings.TrimSpace(s[:idx])
+	right := strings.TrimSpace(s[idx+len("•"):])
+	if isThisDeviceLabel(left) {
+		return right, ""
+	}
+	return left, right
+}
+
+// isThisDeviceLabel reports whether s is the "This Mac" / "This iPhone" /
+// "This iPad" badge FindMy.app shows on the device the user is currently
+// signed into. The label is English-only here; other locales translate it
+// (e.g. "Ce Mac" in French) but those strings are not yet catalogued.
+func isThisDeviceLabel(s string) bool {
+	switch s {
+	case "This Mac", "This iPhone", "This iPad", "This Apple Watch":
+		return true
+	}
+	return false
 }
 
 // ParseDevices groups OCR lines from the Devices sidebar into Device records.

--- a/internal/findmy/findmy_test.go
+++ b/internal/findmy/findmy_test.go
@@ -1,0 +1,60 @@
+package findmy
+
+import "testing"
+
+func TestSplitLocationStaleness(t *testing.T) {
+	tests := []struct {
+		name          string
+		in            string
+		wantLocation  string
+		wantStaleness string
+	}{
+		{
+			name:          "standard location and staleness",
+			in:            "Bellevue, WA • 2 min. ago",
+			wantLocation:  "Bellevue, WA",
+			wantStaleness: "2 min. ago",
+		},
+		{
+			name:          "location only",
+			in:            "Bellevue, WA",
+			wantLocation:  "Bellevue, WA",
+			wantStaleness: "",
+		},
+		{
+			name:          "this mac badge with status",
+			in:            "This Mac • No location found",
+			wantLocation:  "No location found",
+			wantStaleness: "",
+		},
+		{
+			name:          "this iphone badge with status",
+			in:            "This iPhone • No location found",
+			wantLocation:  "No location found",
+			wantStaleness: "",
+		},
+		{
+			name:          "this ipad badge with real location",
+			in:            "This iPad • Home",
+			wantLocation:  "Home",
+			wantStaleness: "",
+		},
+		{
+			name:          "ordinary location starting with This (not a badge)",
+			in:            "This Pleasant Street • Now",
+			wantLocation:  "This Pleasant Street",
+			wantStaleness: "Now",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLoc, gotStale := splitLocationStaleness(tt.in)
+			if gotLoc != tt.wantLocation {
+				t.Errorf("location = %q, want %q", gotLoc, tt.wantLocation)
+			}
+			if gotStale != tt.wantStaleness {
+				t.Errorf("staleness = %q, want %q", gotStale, tt.wantStaleness)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`findmy devices --json` was assigning the string `"This Mac"` as a row's location and `"No location found"` as its staleness. "This Mac" is the badge FindMy.app adds to whichever device you're currently signed into; it isn't a location. After this change, the badge is dropped and the actual status falls into the `location` field.

## Why this matters

Before:

```json
{
  "name": "MacBook Pro (44)",
  "location": "This Mac",
  "staleness": "No location found"
}
```

After:

```json
{
  "name": "MacBook Pro (44)",
  "location": "No location found"
}
```

Same shape as the other no-location rows. Downstream consumers reading `location` no longer have to know "This Mac" is a special string.

## Changes

- `internal/findmy/findmy.go`: `splitLocationStaleness` now checks the left half of a `<x> • <y>` line against a small list of "This <device>" badges. When it matches, the badge is dropped and the right half becomes the location.
- `isThisDeviceLabel` covers "This Mac", "This iPhone", "This iPad", "This Apple Watch" (English; other locales translate the badge but those strings aren't catalogued here yet).
- `internal/findmy/findmy_test.go` (new): table-driven tests cover the badge cases and confirm an ordinary location starting with the word "This" is not mistaken for a badge.

## Testing

- `go test ./...` and `go vet ./...` pass.
- Ran `./bin/findmy devices --json` against my own iCloud account; the `"This Mac"` row no longer carries the badge as a location.
- Non-English locales are unaffected (the badge list is en-only; if you want me to extend it to fr/de/etc, happy to do that in a follow-up after pulling the exact strings from the .loctable files).

AI was used for assistance.
