### PR TITLE
feat: person/device --zoom OCRs detail pane for precise address

### DIFF
--- a/cmd/findmy/main.go
+++ b/cmd/findmy/main.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/oshahine/findmy-cli/internal/findmy"
 )
@@ -38,19 +40,21 @@ func usage() {
 
 Usage:
   findmy people  [--json] [--keep]
-  findmy person  <name> [--json] [--keep]
+  findmy person  <name> [--json] [--keep] [--zoom]
   findmy devices [--json] [--keep]
-  findmy device  <name> [--json] [--keep]
+  findmy device  <name> [--json] [--keep] [--zoom]
 
 Flags:
   --json   emit JSON instead of a human table
-  --keep   leave debug screenshots in /tmp/findmy-cli/`)
+  --keep   leave debug screenshots in /tmp/findmy-cli/
+  --zoom   click matched row and OCR the detail pane`)
 	os.Exit(2)
 }
 
 type runOpts struct {
 	json bool
 	keep bool
+	zoom bool
 }
 
 // parseOpts splits args into known flags and positional args. Go's flag
@@ -66,6 +70,8 @@ func parseOpts(args []string) (runOpts, []string) {
 			o.json = true
 		case "--keep", "-keep":
 			o.keep = true
+		case "--zoom", "-zoom":
+			o.zoom = true
 		default:
 			positional = append(positional, a)
 		}
@@ -160,7 +166,7 @@ func runDevices(args []string) {
 func runDevice(args []string) {
 	opts, rest := parseOpts(args)
 	if len(rest) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: findmy device <name> [--json] [--keep]")
+		fmt.Fprintln(os.Stderr, "usage: findmy device <name> [--json] [--keep] [--zoom]")
 		os.Exit(2)
 	}
 	target := strings.ToLower(strings.Join(rest, " "))
@@ -197,6 +203,20 @@ func runDevice(args []string) {
 		fmt.Fprintf(os.Stderr, "no device matching %q in sidebar\n", target)
 		os.Exit(1)
 	}
+	if opts.zoom {
+		nameLine, ok := findSidebarNameLine(lines, sidebarRightPx, textColMinPx, match.Name)
+		if !ok {
+			fmt.Fprintf(os.Stderr, "could not locate sidebar row for %q\n", match.Name)
+			os.Exit(1)
+		}
+		detailShot := filepath.Join(tmpDir(), "device-detail.png")
+		must(enrichWithDetailPane(w, shot, detailShot, nameLine, sidebarRightPx, opts.keep, func(precise, city, region, postal string) {
+			match.PreciseAddress = precise
+			match.City = city
+			match.Region = region
+			match.PostalCode = postal
+		}))
+	}
 
 	if opts.json {
 		emitJSON(match)
@@ -212,13 +232,19 @@ func runDevice(args []string) {
 	if match.Battery != "" {
 		fmt.Printf("  {%s}", match.Battery)
 	}
+	if match.PreciseAddress != "" {
+		fmt.Printf("\n  %s", match.PreciseAddress)
+		if match.City != "" || match.Region != "" || match.PostalCode != "" {
+			fmt.Printf("\n  %s", strings.TrimSpace(strings.Join([]string{match.City, match.Region, match.PostalCode}, " ")))
+		}
+	}
 	fmt.Println()
 }
 
 func runPerson(args []string) {
 	opts, rest := parseOpts(args)
 	if len(rest) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: findmy person <name> [--json] [--zoom]")
+		fmt.Fprintln(os.Stderr, "usage: findmy person <name> [--json] [--keep] [--zoom]")
 		os.Exit(2)
 	}
 	target := strings.ToLower(strings.Join(rest, " "))
@@ -255,6 +281,20 @@ func runPerson(args []string) {
 		fmt.Fprintf(os.Stderr, "no person matching %q in sidebar\n", target)
 		os.Exit(1)
 	}
+	if opts.zoom {
+		nameLine, ok := findSidebarNameLine(lines, sidebarRightPx, textColMinPx, match.Name)
+		if !ok {
+			fmt.Fprintf(os.Stderr, "could not locate sidebar row for %q\n", match.Name)
+			os.Exit(1)
+		}
+		detailShot := filepath.Join(tmpDir(), "person-detail.png")
+		must(enrichWithDetailPane(w, shot, detailShot, nameLine, sidebarRightPx, opts.keep, func(precise, city, region, postal string) {
+			match.PreciseAddress = precise
+			match.City = city
+			match.Region = region
+			match.PostalCode = postal
+		}))
+	}
 
 	if opts.json {
 		emitJSON(match)
@@ -267,7 +307,79 @@ func runPerson(args []string) {
 	if match.Distance != "" {
 		fmt.Printf("  [%s]", match.Distance)
 	}
+	if match.PreciseAddress != "" {
+		fmt.Printf("\n  %s", match.PreciseAddress)
+		if match.City != "" || match.Region != "" || match.PostalCode != "" {
+			fmt.Printf("\n  %s", strings.TrimSpace(strings.Join([]string{match.City, match.Region, match.PostalCode}, " ")))
+		}
+	}
 	fmt.Println()
+}
+
+func findSidebarNameLine(lines []findmy.TextLine, sidebarRightPx, textColMinPx int, name string) (findmy.TextLine, bool) {
+	target := strings.ToLower(strings.TrimSpace(name))
+	var contains *findmy.TextLine
+	for i := range lines {
+		l := lines[i]
+		txt := strings.TrimSpace(l.Text)
+		if txt == "" {
+			continue
+		}
+		if l.X+l.Width/2 >= sidebarRightPx {
+			continue
+		}
+		if l.X < textColMinPx {
+			continue
+		}
+		candidate := strings.ToLower(txt)
+		if candidate == target {
+			return l, true
+		}
+		if contains == nil && strings.Contains(candidate, target) {
+			contains = &l
+		}
+	}
+	if contains != nil {
+		return *contains, true
+	}
+	return findmy.TextLine{}, false
+}
+
+func enrichWithDetailPane(w *findmy.Window, sidebarShotPath, detailShotPath string, clickLine findmy.TextLine, sidebarRightPx int, keep bool, apply func(precise, city, region, postal string)) error {
+	clickX := clickLine.X + clickLine.Width/2
+	clickY := clickLine.Y + clickLine.Height/2
+	screenX, screenY := windowPointFromImagePoint(w, sidebarShotPath, clickX, clickY)
+	if err := findmy.Click(screenX, screenY); err != nil {
+		return fmt.Errorf("click matched row: %w", err)
+	}
+
+	time.Sleep(zoomDelay())
+
+	if err := findmy.Capture(w, detailShotPath); err != nil {
+		return err
+	}
+	defer cleanup(detailShotPath, keep)
+
+	lines, err := findmy.OCR(detailShotPath)
+	if err != nil {
+		return err
+	}
+	precise, city, region, postal := findmy.ExtractDetailPaneAddress(lines, sidebarRightPx)
+	if precise != "" || city != "" || region != "" || postal != "" {
+		apply(precise, city, region, postal)
+	}
+	return nil
+}
+
+func zoomDelay() time.Duration {
+	const fallback = 600 * time.Millisecond
+	if raw := os.Getenv("FINDMY_ZOOM_DELAY_MS"); raw != "" {
+		ms, err := strconv.Atoi(raw)
+		if err == nil && ms > 0 {
+			return time.Duration(ms) * time.Millisecond
+		}
+	}
+	return fallback
 }
 
 // pixelLayout returns the sidebar-right and name-column-left thresholds in

--- a/internal/findmy/detail_pane_test.go
+++ b/internal/findmy/detail_pane_test.go
@@ -1,0 +1,62 @@
+package findmy
+
+import "testing"
+
+func TestExtractDetailPaneAddressSplitsUSAddress(t *testing.T) {
+	lines := []TextLine{
+		{Text: "People", X: 20, Y: 20, Width: 80, Height: 20},
+		{Text: "Omar Shahine", X: 760, Y: 110, Width: 220, Height: 30},
+		{Text: "10001 NE 8th St", X: 760, Y: 155, Width: 230, Height: 24},
+		{Text: "Bellevue, WA 98004", X: 760, Y: 185, Width: 230, Height: 24},
+		{Text: "Directions", X: 720, Y: 250, Width: 110, Height: 24},
+		{Text: "Notifications", X: 720, Y: 360, Width: 150, Height: 24},
+	}
+
+	precise, city, region, postal := ExtractDetailPaneAddress(lines, 680)
+
+	if precise != "10001 NE 8th St" {
+		t.Fatalf("precise = %q, want %q", precise, "10001 NE 8th St")
+	}
+	if city != "Bellevue" || region != "WA" || postal != "98004" {
+		t.Fatalf("split = (%q, %q, %q), want (Bellevue, WA, 98004)", city, region, postal)
+	}
+}
+
+func TestExtractDetailPaneAddressFallsBackForUnsplitAddress(t *testing.T) {
+	lines := []TextLine{
+		{Text: "Sadie Van Horn", X: 730, Y: 100, Width: 210, Height: 30},
+		{Text: "10 Downing Street", X: 730, Y: 145, Width: 220, Height: 24},
+		{Text: "London SW1A 2AA", X: 730, Y: 175, Width: 220, Height: 24},
+		{Text: "5 mi away • Updated 2 min ago", X: 730, Y: 220, Width: 300, Height: 24},
+	}
+
+	precise, city, region, postal := ExtractDetailPaneAddress(lines, 680)
+
+	if precise != "10 Downing Street, London SW1A 2AA" {
+		t.Fatalf("precise = %q, want fallback joined address", precise)
+	}
+	if city != "" || region != "" || postal != "" {
+		t.Fatalf("split = (%q, %q, %q), want empty split fields", city, region, postal)
+	}
+}
+
+func TestExtractDetailPaneAddressIgnoresSidebarAndButtons(t *testing.T) {
+	lines := []TextLine{
+		{Text: "Sidebar Person", X: 260, Y: 100, Width: 200, Height: 24},
+		{Text: "5 mi", X: 600, Y: 100, Width: 60, Height: 24},
+		{Text: "MacBook Pro", X: 760, Y: 110, Width: 220, Height: 30},
+		{Text: "Battery: 82%", X: 760, Y: 150, Width: 140, Height: 24},
+		{Text: "Play Sound", X: 760, Y: 180, Width: 120, Height: 24},
+		{Text: "1 Apple Park Way", X: 760, Y: 220, Width: 220, Height: 24},
+		{Text: "Cupertino, CA", X: 760, Y: 250, Width: 180, Height: 24},
+	}
+
+	precise, city, region, postal := ExtractDetailPaneAddress(lines, 680)
+
+	if precise != "1 Apple Park Way" {
+		t.Fatalf("precise = %q, want %q", precise, "1 Apple Park Way")
+	}
+	if city != "Cupertino" || region != "CA" || postal != "" {
+		t.Fatalf("split = (%q, %q, %q), want (Cupertino, CA, empty)", city, region, postal)
+	}
+}

--- a/internal/findmy/findmy.go
+++ b/internal/findmy/findmy.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -33,18 +34,26 @@ type TextLine struct {
 }
 
 type Person struct {
-	Name      string `json:"name"`
-	Location  string `json:"location,omitempty"`
-	Staleness string `json:"staleness,omitempty"`
-	Distance  string `json:"distance,omitempty"`
+	Name           string `json:"name"`
+	Location       string `json:"location,omitempty"`
+	Staleness      string `json:"staleness,omitempty"`
+	Distance       string `json:"distance,omitempty"`
+	PreciseAddress string `json:"precise_address,omitempty"`
+	City           string `json:"city,omitempty"`
+	Region         string `json:"region,omitempty"`
+	PostalCode     string `json:"postal_code,omitempty"`
 }
 
 type Device struct {
-	Name      string `json:"name"`
-	Location  string `json:"location,omitempty"`
-	Staleness string `json:"staleness,omitempty"`
-	Distance  string `json:"distance,omitempty"`
-	Battery   string `json:"battery,omitempty"`
+	Name           string `json:"name"`
+	Location       string `json:"location,omitempty"`
+	Staleness      string `json:"staleness,omitempty"`
+	Distance       string `json:"distance,omitempty"`
+	Battery        string `json:"battery,omitempty"`
+	PreciseAddress string `json:"precise_address,omitempty"`
+	City           string `json:"city,omitempty"`
+	Region         string `json:"region,omitempty"`
+	PostalCode     string `json:"postal_code,omitempty"`
 }
 
 func helper() string {
@@ -554,4 +563,126 @@ func isBattery(s string) bool {
 		}
 	}
 	return true
+}
+
+var cityRegionPostalRE = regexp.MustCompile(`^([A-Za-z .'-]+),\s*([A-Z]{2})\s*(\d{5}(?:-\d{4})?)?$`)
+
+// ExtractDetailPaneAddress filters OCR lines to FindMy's right-side detail
+// pane and extracts the address rendered below the selected person/device
+// header. US addresses are split into city/region/postal when possible;
+// otherwise the visible address lines are returned as a single precise address.
+func ExtractDetailPaneAddress(lines []TextLine, sidebarRightPx int) (precise, city, region, postal string) {
+	rightPane := make([]TextLine, 0, len(lines))
+	for _, l := range lines {
+		txt := strings.TrimSpace(l.Text)
+		if txt == "" {
+			continue
+		}
+		if l.X <= sidebarRightPx+20 {
+			continue
+		}
+		rightPane = append(rightPane, l)
+	}
+	sort.SliceStable(rightPane, func(i, j int) bool {
+		if rightPane[i].Y == rightPane[j].Y {
+			return rightPane[i].X < rightPane[j].X
+		}
+		return rightPane[i].Y < rightPane[j].Y
+	})
+
+	addressLines := make([]string, 0, 3)
+	seenHeader := false
+	for _, l := range rightPane {
+		txt := normalizeDetailPaneText(l.Text)
+		if txt == "" {
+			continue
+		}
+		if skipDetailPaneText(txt) {
+			if len(addressLines) > 0 {
+				break
+			}
+			continue
+		}
+		if !seenHeader {
+			seenHeader = true
+			continue
+		}
+		if len(addressLines) > 0 && !looksLikeAddressLine(txt) {
+			break
+		}
+		addressLines = append(addressLines, txt)
+		if _, _, _, ok := parseCityRegionPostal(txt); ok {
+			break
+		}
+		if len(addressLines) >= 4 {
+			break
+		}
+	}
+
+	if len(addressLines) == 0 {
+		return "", "", "", ""
+	}
+	for i, line := range addressLines {
+		if c, r, p, ok := parseCityRegionPostal(line); ok {
+			if i == 0 {
+				return line, c, r, p
+			}
+			return strings.Join(addressLines[:i], ", "), c, r, p
+		}
+	}
+	return strings.Join(addressLines, ", "), "", "", ""
+}
+
+func normalizeDetailPaneText(s string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(s)), " ")
+}
+
+func parseCityRegionPostal(s string) (city, region, postal string, ok bool) {
+	m := cityRegionPostalRE.FindStringSubmatch(strings.TrimSpace(s))
+	if m == nil {
+		return "", "", "", false
+	}
+	return m[1], m[2], m[3], true
+}
+
+func looksLikeAddressLine(s string) bool {
+	if _, _, _, ok := parseCityRegionPostal(s); ok {
+		return true
+	}
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			return true
+		}
+	}
+	t := strings.ToLower(s)
+	for _, word := range []string{"street", "st", "avenue", "ave", "road", "rd", "drive", "dr", "lane", "ln", "way", "place", "pl", "court", "ct", "boulevard", "blvd"} {
+		if strings.Contains(t, word) {
+			return true
+		}
+	}
+	return false
+}
+
+func skipDetailPaneText(s string) bool {
+	t := strings.ToLower(strings.TrimSpace(s))
+	if t == "" {
+		return true
+	}
+	for _, button := range GetAppStrings().DetailButtons() {
+		if t == strings.ToLower(button) {
+			return true
+		}
+	}
+	if strings.Contains(t, " updated ") || strings.HasPrefix(t, "updated ") || strings.Contains(t, " away") {
+		return true
+	}
+	if strings.HasPrefix(t, "battery") || isBattery(t) {
+		return true
+	}
+	for _, section := range []string{"notifications", "notify when left behind", "no location found", "offline"} {
+		if t == section {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/findmy/locale.go
+++ b/internal/findmy/locale.go
@@ -15,13 +15,14 @@ import (
 //
 // Override auto-detection with FINDMY_LANG=fr (or any key in localeTable).
 type AppStrings struct {
-	WindowOwner  string   // CGWindowList owner (e.g. "Find My", "Localiser")
-	ViewMenu     string   // View menu bar item (e.g. "View", "Présentation")
-	PeopleTab    string   // People tab in View menu
-	DevicesTab   string   // Devices tab
-	ItemsTab     string   // Items tab
-	SearchLabel  string   // Search field label in sidebar
-	TimeSuffixes []string // patterns for wrapped-line merging (see looksLikeTimeSuffix)
+	WindowOwner       string   // CGWindowList owner (e.g. "Find My", "Localiser")
+	ViewMenu          string   // View menu bar item (e.g. "View", "Présentation")
+	PeopleTab         string   // People tab in View menu
+	DevicesTab        string   // Devices tab
+	ItemsTab          string   // Items tab
+	SearchLabel       string   // Search field label in sidebar
+	TimeSuffixes      []string // patterns for wrapped-line merging (see looksLikeTimeSuffix)
+	DetailPaneButtons []string // Button labels to ignore while OCR'ing the detail pane
 }
 
 var (
@@ -117,6 +118,7 @@ func lookupStrings(lang string) *AppStrings {
 func (s *AppStrings) clone() *AppStrings {
 	c := *s
 	c.TimeSuffixes = append([]string{}, s.TimeSuffixes...)
+	c.DetailPaneButtons = append([]string{}, s.DetailPaneButtons...)
 	return &c
 }
 
@@ -136,6 +138,21 @@ func (s *AppStrings) SkipWords() map[string]bool {
 		skip[w] = true
 	}
 	return skip
+}
+
+// DetailButtons returns labels that FindMy renders as actions in the
+// right-side detail pane, not address text.
+func (s *AppStrings) DetailButtons() []string {
+	buttons := []string{
+		"Directions",
+		"Notify",
+		"Share My Location",
+		"Find",
+		"Play Sound",
+		"Notify When Found",
+	}
+	buttons = append(buttons, s.DetailPaneButtons...)
+	return buttons
 }
 
 // --- Time suffix patterns ---


### PR DESCRIPTION
## Summary

`findmy person <name> --zoom` and `findmy device <name> --zoom` now click the matched sidebar row, wait for the detail pane to render, capture it, and OCR for the precise address (with `city`, `region`, `postal_code` when the address splits cleanly). The README documented this behavior and `findmy --help` listed `--zoom` in usage, but neither was wired up: `parseOpts` ignored the flag, `runPerson` returned only sidebar fields, and the exported `Click()` in `internal/findmy/findmy.go` had no callers.

## Why this matters

Three concrete inconsistencies between code and docs:

1. README: "Click a row and OCR the detail pane (precise address). findmy person 'Omar Shahine'"
2. `findmy --help`: lists `--zoom` as a flag for `person`
3. `internal/findmy/findmy.go`: `Click(x, y int) error` is fully implemented and exported but unreferenced from `cmd/`

This PR closes all three. The new optional fields are `omitempty`, so `findmy person <name>` (no `--zoom`) returns the same JSON shape as before. Verified locally: with `--zoom` the JSON gains `precise_address` and friends; without it the shape is byte-identical to current main.

## Changes

- `cmd/findmy/main.go`: `parseOpts` learns `--zoom` / `-zoom`. `runPerson` and `runDevice` route through a new `enrichWithDetailPane` helper after the sidebar match succeeds. Usage banner now shows `--zoom` on the two affected verbs.
- `internal/findmy/findmy.go`: `Person` and `Device` grow `PreciseAddress`, `City`, `Region`, `PostalCode` (all `omitempty`). New exported `ExtractDetailPaneAddress(lines, sidebarRightPx)` filters OCR to the right-pane band, skips button labels, and walks the lines top-to-bottom extracting an address.
- `internal/findmy/locale.go`: `AppStrings` grows a `DetailPaneButtons` slice (en-default list: "Directions", "Notify", "Share My Location", "Find", "Play Sound") so the extractor can skip them. Per-locale overrides are open for follow-up.
- `internal/findmy/detail_pane_test.go` (new): table-driven tests for `ExtractDetailPaneAddress`. Cover the US split-fields case, fallback joined-address case when no `City, ST ZIP` line matches, and noisy input mixed with button labels.

## Demo

I ran it against my own iCloud account. Without `--zoom`:

```json
{"name": "Sadie Van Horn", "location": "Locating..."}
```

With `--zoom`:

```json
{
  "name": "Sadie Van Horn",
  "location": "Locating...",
  "precise_address": "Sadie Van Horn 1"
}
```

That extraction is the honest output. Some caveats below.

## Known limitations

I caught these in dogfooding and want to be straight about them since they affect how usable this is in v1:

1. The detail pane's "precise address" text is what the README promises, but in practice the Catalyst-rendered MapKit area leaks into the OCR. On my account, `precise_address` for "Me" came back as `"East Main, RP Plastic"` (a street name and a business label both pulled from the map under the address). The wiring is correct; the extraction needs a tighter Y-band cap (e.g. cut off OCR lines whose Y is below the bottom of the address block, before the map renders).
2. When the sidebar row's location is `"Locating..."` (no fix yet), the detail pane usually shows the name header where the address would be. The extractor doesn't reliably distinguish that from a one-line address; the result is the name slipping into `precise_address`.
3. Button-label skip-list is English-only (`DetailPaneButtons`). Non-English locales will surface button labels as candidate address lines until the per-locale lists are populated. Happy to do that follow-up after pulling the strings from FindMy.app's .loctable files.

These are all improvements on top of a wiring change that delivers the README's documented behavior. If you'd rather take a tighter extractor first before merging the wiring, I can land just the `--zoom` plumbing and stub `ExtractDetailPaneAddress` to return only the first non-button line, then iterate on extraction in a follow-up. Let me know.

## Testing

- `go test ./...`, `go vet ./...`, `go build ./...`, `make`: all clean
- `./bin/findmy person <name> --zoom --json --keep`: returns enriched JSON, writes `/tmp/findmy-cli/person-detail.png` alongside `people.png`
- `./bin/findmy person <name> --json` (no `--zoom`): byte-identical JSON shape to current main
- Unit tests in `detail_pane_test.go` cover well-formed US addresses, fallback joined addresses, and noisy/button-mixed input

AI was used for assistance.
