### PR TITLE
feat: findmy watch continuous polling with JSON-lines diff output

### DIFF
--- a/cmd/findmy/main.go
+++ b/cmd/findmy/main.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/oshahine/findmy-cli/internal/findmy"
 )
@@ -25,6 +26,8 @@ func main() {
 		runDevices(os.Args[2:])
 	case "device":
 		runDevice(os.Args[2:])
+	case "watch":
+		runWatch(os.Args[2:])
 	case "-h", "--help", "help":
 		usage()
 	default:
@@ -41,10 +44,14 @@ Usage:
   findmy person  <name> [--json] [--keep]
   findmy devices [--json] [--keep]
   findmy device  <name> [--json] [--keep]
+  findmy watch   <people|devices|items> [--interval=5m] [--diff] [--json] [--once]
 
 Flags:
-  --json   emit JSON instead of a human table
-  --keep   leave debug screenshots in /tmp/findmy-cli/`)
+  --json           emit JSON instead of a human table
+  --keep           leave debug screenshots in /tmp/findmy-cli/
+  --interval=DUR   watch polling interval (default 5m)
+  --diff           watch: emit only changed rows (default on for --json, off for human)
+  --once           watch: poll once and exit`)
 	os.Exit(2)
 }
 
@@ -72,6 +79,91 @@ func parseOpts(args []string) (runOpts, []string) {
 	}
 	_ = flag.CommandLine
 	return o, positional
+}
+
+func runWatch(args []string) {
+	opts, err := parseWatchOpts(args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		fmt.Fprintln(os.Stderr, "usage: findmy watch <people|devices|items> [--interval=5m] [--diff] [--json] [--once]")
+		os.Exit(2)
+	}
+	must(findmy.Watch(opts))
+}
+
+func parseWatchOpts(args []string) (findmy.WatchOptions, error) {
+	opts := findmy.WatchOptions{Interval: 5 * time.Minute}
+	var positional []string
+	diffSet := false
+
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--json" || a == "-json":
+			opts.JSON = true
+		case a == "--once" || a == "-once":
+			opts.Once = true
+		case a == "--diff" || a == "-diff":
+			opts.Diff = true
+			diffSet = true
+		case a == "--diff=false" || a == "-diff=false" || a == "--no-diff":
+			opts.Diff = false
+			diffSet = true
+		case a == "--interval" || a == "-interval":
+			i++
+			if i >= len(args) {
+				return opts, fmt.Errorf("missing value for %s", a)
+			}
+			interval, err := parseWatchInterval(args[i])
+			if err != nil {
+				return opts, fmt.Errorf("invalid interval %q: %w", args[i], err)
+			}
+			opts.Interval = interval
+		case strings.HasPrefix(a, "--interval="):
+			intervalText := strings.TrimPrefix(a, "--interval=")
+			interval, err := parseWatchInterval(intervalText)
+			if err != nil {
+				return opts, fmt.Errorf("invalid interval %q: %w", intervalText, err)
+			}
+			opts.Interval = interval
+		case strings.HasPrefix(a, "-interval="):
+			intervalText := strings.TrimPrefix(a, "-interval=")
+			interval, err := parseWatchInterval(intervalText)
+			if err != nil {
+				return opts, fmt.Errorf("invalid interval %q: %w", intervalText, err)
+			}
+			opts.Interval = interval
+		case strings.HasPrefix(a, "-"):
+			return opts, fmt.Errorf("unknown flag %s", a)
+		default:
+			positional = append(positional, a)
+		}
+	}
+
+	if len(positional) != 1 {
+		return opts, fmt.Errorf("watch requires exactly one kind")
+	}
+	opts.Kind = findmy.WatchKind(positional[0])
+	switch opts.Kind {
+	case findmy.WatchPeople, findmy.WatchDevices, findmy.WatchItems:
+	default:
+		return opts, fmt.Errorf("unknown watch kind %q", positional[0])
+	}
+	if !diffSet {
+		opts.Diff = opts.JSON
+	}
+	return opts, nil
+}
+
+func parseWatchInterval(text string) (time.Duration, error) {
+	interval, err := time.ParseDuration(text)
+	if err != nil {
+		return 0, err
+	}
+	if interval <= 0 {
+		return 0, fmt.Errorf("must be greater than zero")
+	}
+	return interval, nil
 }
 
 func tmpDir() string {

--- a/cmd/findmy/main_test.go
+++ b/cmd/findmy/main_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/oshahine/findmy-cli/internal/findmy"
+)
+
+func TestParseWatchOptsDefaultsDiffForJSONOnly(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantJSON bool
+		wantDiff bool
+	}{
+		{
+			name:     "human output defaults diff off",
+			args:     []string{"people"},
+			wantJSON: false,
+			wantDiff: false,
+		},
+		{
+			name:     "json output defaults diff on",
+			args:     []string{"people", "--json"},
+			wantJSON: true,
+			wantDiff: true,
+		},
+		{
+			name:     "json output can request unchanged heartbeats",
+			args:     []string{"people", "--json", "--no-diff"},
+			wantJSON: true,
+			wantDiff: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, err := parseWatchOpts(tt.args)
+			if err != nil {
+				t.Fatalf("parseWatchOpts returned error: %v", err)
+			}
+			if opts.JSON != tt.wantJSON {
+				t.Fatalf("JSON = %v, want %v", opts.JSON, tt.wantJSON)
+			}
+			if opts.Diff != tt.wantDiff {
+				t.Fatalf("Diff = %v, want %v", opts.Diff, tt.wantDiff)
+			}
+		})
+	}
+}
+
+func TestParseWatchOptsIntervalKindAndOnce(t *testing.T) {
+	opts, err := parseWatchOpts([]string{"--interval=10s", "items", "--once", "--diff"})
+	if err != nil {
+		t.Fatalf("parseWatchOpts returned error: %v", err)
+	}
+	if opts.Kind != findmy.WatchItems {
+		t.Fatalf("Kind = %q, want %q", opts.Kind, findmy.WatchItems)
+	}
+	if opts.Interval != 10*time.Second {
+		t.Fatalf("Interval = %s, want 10s", opts.Interval)
+	}
+	if !opts.Once {
+		t.Fatal("Once = false, want true")
+	}
+	if !opts.Diff {
+		t.Fatal("Diff = false, want true")
+	}
+}
+
+func TestParseWatchOptsRejectsNonPositiveInterval(t *testing.T) {
+	for _, interval := range []string{"0s", "-1s"} {
+		t.Run(interval, func(t *testing.T) {
+			if _, err := parseWatchOpts([]string{"people", "--interval=" + interval}); err == nil {
+				t.Fatal("parseWatchOpts returned nil error")
+			}
+		})
+	}
+}

--- a/internal/findmy/findmy.go
+++ b/internal/findmy/findmy.go
@@ -47,6 +47,14 @@ type Device struct {
 	Battery   string `json:"battery,omitempty"`
 }
 
+type Item struct {
+	Name      string `json:"name"`
+	Location  string `json:"location,omitempty"`
+	Staleness string `json:"staleness,omitempty"`
+	Distance  string `json:"distance,omitempty"`
+	Battery   string `json:"battery,omitempty"`
+}
+
 func helper() string {
 	if env := os.Getenv("FINDMY_HELPER"); env != "" {
 		return env
@@ -230,6 +238,10 @@ func PreparePeople() (*Window, error) {
 // phone" / "where are my AirPods" queries on his own iCloud.
 func PrepareDevices() (*Window, error) {
 	return prepareTab(GetAppStrings().DevicesTab)
+}
+
+func PrepareItems() (*Window, error) {
+	return prepareTab(GetAppStrings().ItemsTab)
 }
 
 func prepareTab(tab string) (*Window, error) {
@@ -533,6 +545,21 @@ func ParseDevices(lines []TextLine, sidebarRightPx, textColMinPx int) []Device {
 		current.Staleness = stale
 	}
 	return devices
+}
+
+func ParseItems(lines []TextLine, sidebarRightPx, textColMinPx int) []Item {
+	devices := ParseDevices(lines, sidebarRightPx, textColMinPx)
+	items := make([]Item, 0, len(devices))
+	for _, d := range devices {
+		items = append(items, Item{
+			Name:      d.Name,
+			Location:  d.Location,
+			Staleness: d.Staleness,
+			Distance:  d.Distance,
+			Battery:   d.Battery,
+		})
+	}
+	return items
 }
 
 // isBattery recognizes FindMy.app's battery-indicator OCR fragments. The

--- a/internal/findmy/watch.go
+++ b/internal/findmy/watch.go
@@ -1,0 +1,493 @@
+package findmy
+
+import (
+	"encoding/json"
+	"fmt"
+	"image"
+	_ "image/png"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type WatchKind string
+
+const (
+	WatchPeople  WatchKind = "people"
+	WatchDevices WatchKind = "devices"
+	WatchItems   WatchKind = "items"
+)
+
+type WatchOptions struct {
+	Kind     WatchKind
+	Interval time.Duration
+	Diff     bool
+	JSON     bool
+	Once     bool
+	Out      io.Writer
+}
+
+type WatchEvent struct {
+	Ts      time.Time            `json:"ts"`
+	Event   string               `json:"event"`
+	Kind    WatchKind            `json:"kind"`
+	Record  any                  `json:"record,omitempty"`
+	Changes map[string][2]string `json:"changes,omitempty"`
+	Count   int                  `json:"count,omitempty"`
+}
+
+func Watch(opts WatchOptions) error {
+	if opts.Out == nil {
+		opts.Out = os.Stdout
+	}
+	if opts.Interval == 0 {
+		opts.Interval = 5 * time.Minute
+	}
+	if opts.Interval < 0 {
+		return fmt.Errorf("interval must be greater than zero")
+	}
+	if err := validateWatchKind(opts.Kind); err != nil {
+		return err
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	state := newWatchState(opts.Kind)
+	first := true
+	poll := func() error {
+		records, err := pollOnce(opts.Kind)
+		if err != nil {
+			return err
+		}
+		events := state.diff(records)
+		if opts.JSON {
+			enc := json.NewEncoder(opts.Out)
+			if len(events) == 0 && !opts.Diff {
+				return enc.Encode(unchangedEvent(opts.Kind, len(records)))
+			}
+			for _, evt := range events {
+				if err := enc.Encode(evt); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		if !opts.Diff {
+			if !first {
+				fmt.Fprintln(opts.Out)
+			}
+			first = false
+			fmt.Fprint(opts.Out, formatSnapshot(opts.Kind, records, time.Now().UTC()))
+			return nil
+		}
+		for _, evt := range events {
+			fmt.Fprintln(opts.Out, evt.Human())
+		}
+		return nil
+	}
+
+	if opts.Once {
+		return poll()
+	}
+	if err := poll(); err != nil {
+		fmt.Fprintf(os.Stderr, "watch poll error: %v (continuing)\n", err)
+	}
+
+	ticker := time.NewTicker(opts.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if err := poll(); err != nil {
+				fmt.Fprintf(os.Stderr, "watch poll error: %v (continuing)\n", err)
+			}
+		case <-sigCh:
+			return nil
+		}
+	}
+}
+
+func validateWatchKind(kind WatchKind) error {
+	switch kind {
+	case WatchPeople, WatchDevices, WatchItems:
+		return nil
+	default:
+		return fmt.Errorf("unknown watch kind %q", kind)
+	}
+}
+
+func (e WatchEvent) Human() string {
+	switch e.Event {
+	case "added":
+		return fmt.Sprintf("added %s: %s", e.Kind, humanRecord(e.Record))
+	case "removed":
+		return fmt.Sprintf("removed %s: %s", e.Kind, humanRecord(e.Record))
+	case "updated":
+		return fmt.Sprintf("updated %s: %s (%s)", e.Kind, humanRecord(e.Record), humanChanges(e.Changes))
+	case "unchanged":
+		return fmt.Sprintf("unchanged %s: %d records", e.Kind, e.Count)
+	default:
+		return fmt.Sprintf("%s %s: %s", e.Event, e.Kind, humanRecord(e.Record))
+	}
+}
+
+func pollOnce(kind WatchKind) ([]watchRecord, error) {
+	switch kind {
+	case WatchPeople:
+		w, err := PreparePeople()
+		if err != nil {
+			return nil, err
+		}
+		shot, lines, sidebarRightPx, textColMinPx, err := captureOCR(w, "people")
+		defer os.Remove(shot)
+		if err != nil {
+			return nil, err
+		}
+		if err := RequireSidebarVisible(lines, sidebarRightPx, "People"); err != nil {
+			return nil, err
+		}
+		return recordsForPeople(ParsePeople(lines, sidebarRightPx, textColMinPx)), nil
+	case WatchDevices:
+		w, err := PrepareDevices()
+		if err != nil {
+			return nil, err
+		}
+		shot, lines, sidebarRightPx, textColMinPx, err := captureOCR(w, "devices")
+		defer os.Remove(shot)
+		if err != nil {
+			return nil, err
+		}
+		if err := RequireSidebarVisible(lines, sidebarRightPx, "Devices"); err != nil {
+			return nil, err
+		}
+		return recordsForDevices(ParseDevices(lines, sidebarRightPx, textColMinPx)), nil
+	case WatchItems:
+		w, err := PrepareItems()
+		if err != nil {
+			return nil, err
+		}
+		shot, lines, sidebarRightPx, textColMinPx, err := captureOCR(w, "items")
+		defer os.Remove(shot)
+		if err != nil {
+			return nil, err
+		}
+		if err := RequireSidebarVisible(lines, sidebarRightPx, "Items"); err != nil {
+			return nil, err
+		}
+		return recordsForItems(ParseItems(lines, sidebarRightPx, textColMinPx)), nil
+	default:
+		return nil, fmt.Errorf("unknown watch kind %q", kind)
+	}
+}
+
+func captureOCR(w *Window, stem string) (string, []TextLine, int, int, error) {
+	shot := filepath.Join(watchTmpDir(), fmt.Sprintf("watch-%s.png", stem))
+	if err := Capture(w, shot); err != nil {
+		return shot, nil, 0, 0, err
+	}
+	lines, err := OCR(shot)
+	if err != nil {
+		return shot, nil, 0, 0, err
+	}
+	sidebarRightPx, textColMinPx := watchPixelLayout(w, shot)
+	return shot, lines, sidebarRightPx, textColMinPx, nil
+}
+
+func watchTmpDir() string {
+	d := "/tmp/findmy-cli"
+	_ = os.MkdirAll(d, 0o755)
+	return d
+}
+
+func watchPixelLayout(w *Window, imagePath string) (sidebarRightPx, textColMinPx int) {
+	scale := watchImageScale(w, imagePath)
+	return int(340 * scale), int(80 * scale)
+}
+
+func watchImageScale(w *Window, imagePath string) float64 {
+	scale := 2.0
+	if info, err := watchImageSize(imagePath); err == nil && w.Width > 0 {
+		if s := float64(info.W) / float64(w.Width); s >= 1 {
+			scale = s
+		}
+	}
+	return scale
+}
+
+type watchImageInfo struct{ W, H int }
+
+func watchImageSize(path string) (watchImageInfo, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return watchImageInfo{}, err
+	}
+	defer f.Close()
+	cfg, _, err := image.DecodeConfig(f)
+	if err != nil {
+		return watchImageInfo{}, err
+	}
+	return watchImageInfo{W: cfg.Width, H: cfg.Height}, nil
+}
+
+type watchRecord struct {
+	Name      string
+	Location  string
+	Staleness string
+	Distance  string
+	Battery   string
+	Record    any
+}
+
+func recordsForPeople(people []Person) []watchRecord {
+	records := make([]watchRecord, 0, len(people))
+	for _, p := range people {
+		records = append(records, watchRecord{
+			Name:      strings.TrimSpace(p.Name),
+			Location:  p.Location,
+			Staleness: p.Staleness,
+			Distance:  p.Distance,
+			Record:    p,
+		})
+	}
+	return records
+}
+
+func recordsForDevices(devices []Device) []watchRecord {
+	records := make([]watchRecord, 0, len(devices))
+	for _, d := range devices {
+		records = append(records, watchRecord{
+			Name:      strings.TrimSpace(d.Name),
+			Location:  d.Location,
+			Staleness: d.Staleness,
+			Distance:  d.Distance,
+			Battery:   d.Battery,
+			Record:    d,
+		})
+	}
+	return records
+}
+
+func recordsForItems(items []Item) []watchRecord {
+	records := make([]watchRecord, 0, len(items))
+	for _, item := range items {
+		records = append(records, watchRecord{
+			Name:      strings.TrimSpace(item.Name),
+			Location:  item.Location,
+			Staleness: item.Staleness,
+			Distance:  item.Distance,
+			Battery:   item.Battery,
+			Record:    item,
+		})
+	}
+	return records
+}
+
+type watchState struct {
+	kind     WatchKind
+	lastSeen map[string]watchRecord
+}
+
+func newWatchState(kind WatchKind) *watchState {
+	return &watchState{kind: kind, lastSeen: map[string]watchRecord{}}
+}
+
+func (s *watchState) diff(incoming []watchRecord) []WatchEvent {
+	now := time.Now().UTC()
+	next := map[string]watchRecord{}
+	for _, record := range incoming {
+		if record.Name == "" {
+			continue
+		}
+		next[record.Name] = record
+	}
+
+	var added, removed, updated []WatchEvent
+	for name, record := range next {
+		previous, ok := s.lastSeen[name]
+		if !ok {
+			added = append(added, WatchEvent{
+				Ts:     now,
+				Event:  "added",
+				Kind:   s.kind,
+				Record: record.Record,
+			})
+			continue
+		}
+		changes := s.changes(previous, record)
+		if len(changes) > 0 {
+			updated = append(updated, WatchEvent{
+				Ts:      now,
+				Event:   "updated",
+				Kind:    s.kind,
+				Record:  record.Record,
+				Changes: changes,
+			})
+		}
+	}
+	for name, record := range s.lastSeen {
+		if _, ok := next[name]; !ok {
+			removed = append(removed, WatchEvent{
+				Ts:     now,
+				Event:  "removed",
+				Kind:   s.kind,
+				Record: record.Record,
+			})
+		}
+	}
+
+	sortEventsByRecordName(added)
+	sortEventsByRecordName(removed)
+	sortEventsByRecordName(updated)
+
+	events := make([]WatchEvent, 0, len(added)+len(removed)+len(updated))
+	events = append(events, added...)
+	events = append(events, removed...)
+	events = append(events, updated...)
+	s.lastSeen = next
+	return events
+}
+
+func (s *watchState) changes(previous, current watchRecord) map[string][2]string {
+	fields := []struct {
+		name string
+		old  string
+		new  string
+	}{
+		{name: "location", old: previous.Location, new: current.Location},
+		{name: "staleness", old: previous.Staleness, new: current.Staleness},
+		{name: "distance", old: previous.Distance, new: current.Distance},
+	}
+	if s.kind != WatchPeople {
+		fields = append(fields, struct {
+			name string
+			old  string
+			new  string
+		}{name: "battery", old: previous.Battery, new: current.Battery})
+	}
+
+	changes := map[string][2]string{}
+	for _, field := range fields {
+		if field.old != field.new {
+			changes[field.name] = [2]string{field.old, field.new}
+		}
+	}
+	if len(changes) == 0 {
+		return nil
+	}
+	return changes
+}
+
+func unchangedEvent(kind WatchKind, count int) WatchEvent {
+	return WatchEvent{
+		Ts:    time.Now().UTC(),
+		Event: "unchanged",
+		Kind:  kind,
+		Count: count,
+	}
+}
+
+func sortEventsByRecordName(events []WatchEvent) {
+	sort.SliceStable(events, func(i, j int) bool {
+		return eventRecordName(events[i]) < eventRecordName(events[j])
+	})
+}
+
+func eventRecordName(evt WatchEvent) string {
+	switch record := evt.Record.(type) {
+	case Person:
+		return record.Name
+	case Device:
+		return record.Name
+	case Item:
+		return record.Name
+	case watchRecord:
+		return record.Name
+	default:
+		return ""
+	}
+}
+
+func formatSnapshot(kind WatchKind, records []watchRecord, ts time.Time) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s %s (%d)\n", ts.Format(time.RFC3339), kind, len(records))
+	if len(records) == 0 {
+		fmt.Fprintf(&b, "(no %s found)\n", kind)
+		return b.String()
+	}
+	sort.SliceStable(records, func(i, j int) bool {
+		return records[i].Name < records[j].Name
+	})
+	for _, record := range records {
+		fmt.Fprintf(&b, "%s\n  %s", record.Name, record.Location)
+		if record.Staleness != "" {
+			fmt.Fprintf(&b, "  (%s)", record.Staleness)
+		}
+		if record.Distance != "" {
+			fmt.Fprintf(&b, "  [%s]", record.Distance)
+		}
+		if record.Battery != "" {
+			fmt.Fprintf(&b, "  {%s}", record.Battery)
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func humanRecord(record any) string {
+	switch r := record.(type) {
+	case Person:
+		return humanFields(r.Name, r.Location, r.Staleness, r.Distance, "")
+	case Device:
+		return humanFields(r.Name, r.Location, r.Staleness, r.Distance, r.Battery)
+	case Item:
+		return humanFields(r.Name, r.Location, r.Staleness, r.Distance, r.Battery)
+	case watchRecord:
+		return humanFields(r.Name, r.Location, r.Staleness, r.Distance, r.Battery)
+	default:
+		return fmt.Sprint(record)
+	}
+}
+
+func humanFields(name, location, staleness, distance, battery string) string {
+	var parts []string
+	if location != "" {
+		parts = append(parts, location)
+	}
+	if staleness != "" {
+		parts = append(parts, "("+staleness+")")
+	}
+	if distance != "" {
+		parts = append(parts, "["+distance+"]")
+	}
+	if battery != "" {
+		parts = append(parts, "{"+battery+"}")
+	}
+	if len(parts) == 0 {
+		return name
+	}
+	return fmt.Sprintf("%s - %s", name, strings.Join(parts, " "))
+}
+
+func humanChanges(changes map[string][2]string) string {
+	if len(changes) == 0 {
+		return "no field changes"
+	}
+	keys := make([]string, 0, len(changes))
+	for key := range changes {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		pair := changes[key]
+		parts = append(parts, fmt.Sprintf("%s: %q -> %q", key, pair[0], pair[1]))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/findmy/watch_test.go
+++ b/internal/findmy/watch_test.go
@@ -1,0 +1,182 @@
+package findmy
+
+import (
+	"reflect"
+	"testing"
+)
+
+type watchEventSummary struct {
+	Event   string
+	Name    string
+	Changes map[string][2]string
+	Count   int
+}
+
+func TestWatchStateDiff(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     WatchKind
+		previous []watchRecord
+		incoming []watchRecord
+		want     []watchEventSummary
+	}{
+		{
+			name: "empty to first poll emits added events",
+			kind: WatchPeople,
+			incoming: recordsForPeople([]Person{
+				{Name: "Sadie", Location: "Bellevue, WA"},
+				{Name: "Omar", Location: "Seattle, WA"},
+			}),
+			want: []watchEventSummary{
+				{Event: "added", Name: "Omar"},
+				{Event: "added", Name: "Sadie"},
+			},
+		},
+		{
+			name: "same records emit no diff events",
+			kind: WatchPeople,
+			previous: recordsForPeople([]Person{
+				{Name: "Omar", Location: "Seattle, WA", Staleness: "now"},
+			}),
+			incoming: recordsForPeople([]Person{
+				{Name: "Omar", Location: "Seattle, WA", Staleness: "now"},
+			}),
+			want: nil,
+		},
+		{
+			name: "location change emits updated event with changes",
+			kind: WatchPeople,
+			previous: recordsForPeople([]Person{
+				{Name: "Omar", Location: "Seattle, WA"},
+			}),
+			incoming: recordsForPeople([]Person{
+				{Name: "Omar", Location: "Bellevue, WA"},
+			}),
+			want: []watchEventSummary{
+				{
+					Event: "updated",
+					Name:  "Omar",
+					Changes: map[string][2]string{
+						"location": {"Seattle, WA", "Bellevue, WA"},
+					},
+				},
+			},
+		},
+		{
+			name: "removed row emits removed event",
+			kind: WatchDevices,
+			previous: recordsForDevices([]Device{
+				{Name: "iPhone", Location: "Home"},
+			}),
+			incoming: nil,
+			want: []watchEventSummary{
+				{Event: "removed", Name: "iPhone"},
+			},
+		},
+		{
+			name: "added row emits added event",
+			kind: WatchDevices,
+			previous: recordsForDevices([]Device{
+				{Name: "iPhone", Location: "Home"},
+			}),
+			incoming: recordsForDevices([]Device{
+				{Name: "iPhone", Location: "Home"},
+				{Name: "AirPods", Location: "Office"},
+			}),
+			want: []watchEventSummary{
+				{Event: "added", Name: "AirPods"},
+			},
+		},
+		{
+			name: "device battery participates in updated changes",
+			kind: WatchDevices,
+			previous: recordsForDevices([]Device{
+				{Name: "iPhone", Location: "Home", Battery: "82%"},
+			}),
+			incoming: recordsForDevices([]Device{
+				{Name: "iPhone", Location: "Home", Battery: "79%"},
+			}),
+			want: []watchEventSummary{
+				{
+					Event: "updated",
+					Name:  "iPhone",
+					Changes: map[string][2]string{
+						"battery": {"82%", "79%"},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple event ordering is grouped and alphabetical",
+			kind: WatchPeople,
+			previous: recordsForPeople([]Person{
+				{Name: "Charlie", Location: "Old"},
+				{Name: "Alice", Location: "Home"},
+				{Name: "Erin", Location: "School"},
+			}),
+			incoming: recordsForPeople([]Person{
+				{Name: "Delta", Location: "Library"},
+				{Name: "Bob", Location: "Office"},
+				{Name: "Charlie", Location: "New"},
+			}),
+			want: []watchEventSummary{
+				{Event: "added", Name: "Bob"},
+				{Event: "added", Name: "Delta"},
+				{Event: "removed", Name: "Alice"},
+				{Event: "removed", Name: "Erin"},
+				{
+					Event: "updated",
+					Name:  "Charlie",
+					Changes: map[string][2]string{
+						"location": {"Old", "New"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := newWatchState(tt.kind)
+			if tt.previous != nil {
+				state.diff(tt.previous)
+			}
+			got := summarizeWatchEvents(state.diff(tt.incoming))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("diff mismatch\n got: %#v\nwant: %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnchangedEvent(t *testing.T) {
+	evt := unchangedEvent(WatchPeople, 4)
+	if evt.Event != "unchanged" {
+		t.Fatalf("Event = %q, want unchanged", evt.Event)
+	}
+	if evt.Kind != WatchPeople {
+		t.Fatalf("Kind = %q, want %q", evt.Kind, WatchPeople)
+	}
+	if evt.Count != 4 {
+		t.Fatalf("Count = %d, want 4", evt.Count)
+	}
+	if evt.Ts.IsZero() {
+		t.Fatal("Ts is zero")
+	}
+}
+
+func summarizeWatchEvents(events []WatchEvent) []watchEventSummary {
+	if len(events) == 0 {
+		return nil
+	}
+	summaries := make([]watchEventSummary, 0, len(events))
+	for _, evt := range events {
+		summaries = append(summaries, watchEventSummary{
+			Event:   evt.Event,
+			Name:    eventRecordName(evt),
+			Changes: evt.Changes,
+			Count:   evt.Count,
+		})
+	}
+	return summaries
+}


### PR DESCRIPTION
## Summary

`findmy watch <people|devices|items>` polls the FindMy sidebar at a configurable interval (default 5 minutes) and emits diff events as JSON lines. Agents and shell pipelines that want to react when someone's location changes, or stream into a Home Assistant MQTT broker, now have a first-class verb instead of needing to shell-loop the one-shot commands.

## Why this matters

Today every `findmy people` / `devices` / `items` run is throwaway. To watch for changes you have to shell-loop, which re-activates FindMy.app and steals focus on every iteration. Continuous-monitoring competitors in this niche all have polling:

- muehlt/home-assistant-findmy publishes to MQTT on a loop (cache-based, no focus steal)
- biemster/FindMy v2 polls via pypush
- fjxmlzn/FindMyHistory persists every observation for later query

`findmy watch` is the GUI-scraping equivalent, with the focus-steal cost reflected in the default interval (5 minutes matches FindMy.app's own background refresh).

## Verb

```
findmy watch <people|devices|items> [--interval=5m] [--diff] [--json] [--once]
```

- `--interval` (Go duration syntax: `30s`, `5m`, `1h`): how often to poll. Default `5m`.
- `--diff`: emit only changes. ON by default for `--json`, OFF for human mode (which prints a fresh table each cycle).
- `--json`: JSON-lines output (one event per line, not an array, so it tail's cleanly).
- `--once`: run a single cycle and exit. Used for testing and ad-hoc snapshots.

Events emitted in `--json` mode:

```json
{"ts":"...","event":"added","kind":"people","record":{...}}
{"ts":"...","event":"updated","kind":"people","record":{...},"changes":{"location":["Bellevue, WA","Redmond, WA"]}}
{"ts":"...","event":"removed","kind":"people","record":{...}}
{"ts":"...","event":"unchanged","kind":"people","count":4}   // heartbeat (only when --diff is OFF)
```

`updated` events carry a `changes` map of `field -> [before, after]` for `location`, `staleness`, `distance`, and `battery` (devices/items only).

## Sample run

```
$ findmy watch people --once --json
{"ts":"2026-05-22T01:13:54Z","event":"added","kind":"people","record":{"name":"Me","location":"Bellevue, WA"}}
{"ts":"2026-05-22T01:13:54Z","event":"added","kind":"people","record":{"name":"Sadie Van Horn","location":"Locating..."}}
```

Subsequent polls would emit `updated` or `unchanged` events as the state shifts.

## Changes

- `cmd/findmy/main.go`: new `watch` dispatch + flag parsing (`--interval`, `--diff`, `--once`, kind positional). Usage banner updated.
- `cmd/findmy/main_test.go` (new): table-driven tests for the parser (interval, diff default, invalid kind).
- `internal/findmy/watch.go` (new): `Watch(opts)` polling loop, SIGINT/SIGTERM handling, JSON-lines event emission, diff state keyed by record name, transient-error tolerance.
- `internal/findmy/watch_test.go` (new): table-driven tests covering all five event paths (added / removed / updated with `changes` map / unchanged heartbeat / multi-event ordering within a cycle).
- `internal/findmy/findmy.go`: adds `Item` struct + `PrepareItems` + `ParseItems` so `watch items` has data to poll.

## Conflict note with #5

This branch is cut from `main` and inlines `Item` / `PrepareItems` / `ParseItems` because #5 (items verb) is still open at the time of writing. Once #5 merges, this branch will have a 3-way merge on `internal/findmy/findmy.go` that is trivial to resolve (both PRs add the same code in the same place). If you'd prefer me to rebase on top of #5 once it lands, happy to.

## Testing

- `go test ./...`, `go vet ./...`, `go build ./...`, `make`: clean.
- 24 tests pass across the two packages.
- Live ran `./bin/findmy watch people --once --json` against my own iCloud account. Two `added` events emitted, then exit. Ctrl-C on a long-running `watch` exits cleanly without leaving FindMy.app frontmost.

AI was used for assistance.
