### PR TITLE
docs: add consent/authorization boundaries to address ClawHub security audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ on-disk caches are encrypted with keychain-bound keys, so this tool drives the
 GUI: it activates FindMy.app, switches to the People, Devices, or Items tab,
 screenshots the window, and runs Vision OCR on the result.
 
+**Privacy & consent.** This is read-only and consent-bounded. It can only see the
+people who have already opted in to share their location with this Mac's Apple ID
+in Apple's Find My, plus your own devices and items. It returns coarse location
+only (city/state, staleness, distance), bypasses no Apple access control, and
+initiates no network traffic — everything stays on-device. Use it to locate
+consenting friends and family, not to monitor or track anyone without their
+knowledge and consent.
+
 ## Why a Go CLI plus a Swift helper
 
 The macOS APIs we need (Vision, CoreGraphics window list, CGEvent click) have no

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "findmy-cli",
   "name": "Find My",
-  "description": "macOS-only. Query Find My friend locations by driving FindMy.app via screen capture and Vision OCR. Returns name, coarse location (city, state), staleness, and distance. Shells out to the `findmy` binary (install via `brew install omarshahine/tap/findmy-cli`). Requires Screen Recording permission granted to the host process.",
+  "description": "macOS-only. Read-only. Query the locations of friends who have already opted in to share with this Mac's Apple ID in Apple's Find My, by driving FindMy.app via screen capture and Vision OCR. Returns name, coarse location (city, state), staleness, and distance — never precise coordinates or history. It cannot surface anyone who has not consented to share, and does not bypass any Apple access control. For personal use locating consenting friends and family, not for surveillance or tracking people without their knowledge. Shells out to the `findmy` binary (install via `brew install omarshahine/tap/findmy-cli`). Requires Screen Recording permission granted to the host process.",
   "version": "0.3.1",
   "configSchema": {
     "type": "object",

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "findmy-cli",
   "version": "0.3.1",
-  "description": "OpenClaw plugin for macOS Find My friend locations. Shells out to the findmy CLI to drive FindMy.app via screen capture and Vision OCR. macOS-only. Install findmy first via `brew install omarshahine/tap/findmy-cli`.",
+  "description": "OpenClaw plugin for macOS Find My friend locations. Read-only and consent-bounded: it reads only the friends who have already opted in to share their location with this Mac's Apple ID, returns coarse location only, and cannot surface anyone who has not consented. For personal use locating consenting friends and family, not surveillance. Shells out to the findmy CLI to drive FindMy.app via screen capture and Vision OCR. macOS-only. Install findmy first via `brew install omarshahine/tap/findmy-cli`.",
   "type": "module",
   "openclaw": {
     "extensions": [

--- a/openclaw/skills/findmy/SKILL.md
+++ b/openclaw/skills/findmy/SKILL.md
@@ -29,6 +29,21 @@ Two tools available, both shell out to the `findmy` binary which drives
 FindMy.app via screen capture and Vision OCR. Read-only — never mutates
 FindMy.app state.
 
+## Privacy & consent (read first)
+
+- These tools can only read people who have **already opted in** to share their
+  location with this Mac's Apple ID in Apple's Find My. Sharing is mutual and the
+  other person controls it — the plugin cannot see anyone who has not consented,
+  and does not bypass any Apple access control.
+- Returns coarse location only (city/state, staleness, distance), the same data
+  FindMy.app shows the signed-in user. No precise coordinates, history, or
+  background tracking.
+- Intended for the Mac's owner to locate consenting friends and family. **Not a
+  surveillance tool** — never use it to monitor or track someone without their
+  knowledge and consent.
+- When a result is `Paused` or stale, surface that plainly; the position may be
+  hours or days old, and reporting it as current is misleading.
+
 ## When to use
 
 - "Where is Omar?"        → call `findmy_person` with `name: "Omar"`
@@ -59,9 +74,9 @@ take, and wait for confirmation. Examples:
 - ❌ Calling `restaurant_book` based purely on the inferred location, no
   confirmation step.
 
-Read-only location queries themselves never need approval — those are what
-the user asked for. The approval gate is on the *next* tool call that
-turns location into an action.
+Read-only location queries themselves are what the account owner asked for and
+are consent-bounded (only people already sharing show up). The approval gate is
+on the *next* tool call that turns location into an action.
 
 ## Output shape
 

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -13,6 +13,22 @@
  * - No eval, Function(), dynamic import, or curl|sh install steps.
  * - User input (`name` for findmy_person) is length-bounded and ASCII-class
  *   validated below before passing to execFile.
+ *
+ * Privacy & authorized use:
+ * - This tool can ONLY read people who have already chosen to share their
+ *   location with this Mac's Apple ID in Apple's Find My. Sharing is a mutual,
+ *   opt-in relationship managed by Apple — there is no way for this plugin to
+ *   surface anyone who has not consented at the Apple ID level. It does not
+ *   bypass, weaken, or circumvent any of Apple's access controls.
+ * - It surfaces only the coarse data FindMy.app already shows the signed-in
+ *   user (city/state, staleness, distance) — no precise coordinates, location
+ *   history, or background tracking.
+ * - Intended for personal use by the owner of this Mac on friends and family
+ *   who are knowingly sharing with them. It is NOT a surveillance tool and
+ *   must not be used to monitor anyone without their knowledge and consent.
+ * - Each tool's `description` states these boundaries (read-only,
+ *   consent-bounded, coarse-only) so they stay in the model's context whenever
+ *   the tool is offered.
  */
 
 import { definePluginEntry } from 'openclaw/plugin-sdk/plugin-entry';
@@ -63,14 +79,14 @@ const TOOLS: ToolDef[] = [
 	{
 		name: 'findmy_people',
 		description:
-			'List every friend in the FindMy.app People sidebar. Returns name, coarse location (city, state), staleness, and distance for each person. Use for "who is where", "anyone near downtown", or any broad location query. Each entry includes a `staleness` field — if "Paused", the friend has paused location sharing and the location is the last known position.',
+			'List every friend in the FindMy.app People sidebar — i.e. the people who have already opted in to share their location with this Mac\'s Apple ID. Returns name, coarse location (city, state), staleness, and distance for each. Use for "who is where", "anyone near downtown", or any broad location query. Each entry includes a `staleness` field — if "Paused", the friend has paused location sharing and the location is the last known position. Read-only and consent-bounded: it cannot surface anyone who has not chosen to share, and surfaces only the coarse data Find My already shows the signed-in user.',
 		parameters: Type.Object({}),
 		buildArgs: () => ['people', '--json'],
 	},
 	{
 		name: 'findmy_person',
 		description:
-			'Look up a single friend by name (case-insensitive substring match). Returns the same shape as findmy_people but filtered. Use for "where is X", "is X home", "how far is X". Match works on partial names — "sarah" matches "Sarah Shahine".',
+			'Look up a single friend by name (case-insensitive substring match) among the people who are sharing their location with this Mac\'s Apple ID. Returns the same shape as findmy_people but filtered. Use for "where is X", "is X home", "how far is X". Match works on partial names — "sarah" matches "Sarah Shahine". Read-only and consent-bounded: it can only return someone who has opted in to share, and surfaces only coarse location.',
 		parameters: Type.Object({
 			name: Type.String({
 				description: 'Friend name or substring (case-insensitive).',


### PR DESCRIPTION
## Summary

Addresses the two Medium findings on the [ClawHub security audit](https://clawhub.ai/plugins/findmy-cli/security-audit) (outcome: **Review**, VirusTotal clean 52/52):

1. **Missing User Warnings** (Medium, 92%) — plugin exposed sensitive friend location data without consent framing or warnings.
2. **Natural-Language Policy Violations** (Medium, 74%) — docs advertised location access + screen-recording permission without clear consent/authorization boundaries.

## The fix

The strongest counter to the "privacy/stalking risk" framing is a fact the docs never stated plainly: **this plugin is read-only and can ONLY surface people who have already opted in to share their location with this Mac's Apple ID in Apple's Find My.** It bypasses no Apple access control, returns coarse location only (city/state, staleness, distance — no precise coordinates or history), initiates no network traffic, and is meant for locating consenting friends and family, not surveillance.

That boundary is now stated across every natural-language surface the audit reads, plus the tool descriptions the model sees at call time:

| File | Change |
|------|--------|
| `README.md` | Privacy & consent note up top |
| `openclaw/openclaw.plugin.json` | consent-bounded `description` |
| `openclaw/package.json` | consent-bounded `description` |
| `openclaw/skills/findmy/SKILL.md` | new Privacy & consent section; reframed the "needs no approval" framing to "consent-bounded" |
| `openclaw/src/index.ts` | authorized-use header comment + consent-bounded tool descriptions |

The repeated `"read-only and need no approval"` phrasing (which a scanner reads as "no consent gate") is reframed to `"read-only and consent-bounded"` — still accurate, since the lookup answers a question the account owner asked, but the approval gate is explicitly placed on any *downstream* mutating action.

## Notes

- No code behavior change; `tsc --noEmit` and `npm run build` both pass.
- I checked the SDK for an execution-time `requiresApproval`/`promptGuidelines` hook on `registerTool` — it has none for plugin tools, so the tool `description` (in-context at call time) is the right place for the consent signal.
- No version bump in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)