### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+# Grouped and monthly on purpose: ungrouped weekly updates across this
+# fleet would be dozens of PRs a week. One PR per ecosystem per month
+# is something a person can actually read.
+updates:
+  # The real supply-chain surface: these workflows carry signing certs,
+  # notarization credentials and publish tokens.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: deps
+  - package-ecosystem: npm
+    directory: "/openclaw"
+    schedule:
+      interval: monthly
+    groups:
+      production:
+        dependency-type: production
+      development:
+        dependency-type: development
+    commit-message:
+      prefix: deps


### PR DESCRIPTION
Grouped monthly updates.

- `github-actions` — these workflows carry signing certs, notarization credentials and publish tokens, which is the supply-chain surface that actually matters here.
- `npm` — this package is something other people install.

Grouping and the monthly interval are deliberate: ungrouped weekly updates across the fleet would be dozens of PRs a week.