### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/plugin-inspector.yml
+++ b/.github/workflows/plugin-inspector.yml
@@ -12,8 +12,8 @@ jobs:
       run:
         working-directory: openclaw
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
         with:
           node-version: 24
           cache: npm
@@ -24,7 +24,7 @@ jobs:
       # "//" note there before removing either.
       - run: npm run typecheck
       - run: npx @openclaw/plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         if: always()
         with:
           name: plugin-inspector-reports

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
         with:
           node-version: 22
 

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -44,7 +44,7 @@ jobs:
           echo "Resolved v$VERSION -> $SHA256"
 
       - name: Checkout tap
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           repository: ${{ env.TAP_REPO }}
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Setup Node.js
         # Node 24 ships with npm 11.x. Trusted Publisher OIDC requires
         # npm >= 11.5.1 (per https://docs.npmjs.com/trusted-publishers).
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
Pins every `uses:` in this repo's workflows to a full 40-character commit SHA, keeping the version as a trailing comment.

**Why.** An upstream tag retarget on a mutable major (`@v7`, `@v4`) silently changes the code that runs — including in workflows that hold production Cloudflare tokens. A SHA cannot be moved.

**Why this stays maintainable.** Dependabot's `github-actions` ecosystem is already configured in this repo, and it reads the trailing `# vN` comment to keep both the pin and the annotation current. Pinning without it would just freeze the actions.

**How the SHAs were resolved.** Each from the tag it currently points at, via `gh api /repos/<owner>/<repo>/git/ref/tags/<tag>`, dereferencing annotated tag objects through `/git/tags/<sha>` to the underlying commit. Resolved per repo, not copied between repos — different repos sit on different majors.

**Verification.** A wrong SHA fails at run time, not parse time, so a green run on this PR is the proof the pins resolve.

## Pinned

 .github/workflows/plugin-inspector.yml | 6 +++---
 .github/workflows/publish-clawhub.yml  | 4 ++--
 .github/workflows/publish-homebrew.yml | 2 +-
 .github/workflows/publish-npm.yml      | 4 ++--
 4 files changed, 8 insertions(+), 8 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDD6P9ft7DNNbrXpNWvCsk