### PR TITLE
Add `findmy ring`, `findmy phone` and device aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,41 @@ findmy item "AirPods Pro" --json
 # Query the SQLite history ledger populated by people/devices runs.
 findmy log "Omar Shahine" --since=24h
 findmy log "Omar's iPhone" --kind=devices --limit=10 --json
+
+### Ring a device
+
+`ring` finds the device by scrolling the Devices sidebar, opens its card on the
+map, and clicks **Play Sound**. It is a dry run unless you pass `--confirm`, so
+you can check it found the right device before anything makes noise.
+
+```bash
+findmy ring "Omar's iPhone"             # locates the button, does not click
+findmy ring "Omar's iPhone" --confirm   # actually plays the sound
+```
+
+Ringing needs Accessibility as well as Screen Recording, since it synthesizes
+clicks. It activates Find My and switches back to the app you were in when it
+finishes.
+
+### Aliases
+
+Aliases save typing the exact device name, and live in
+`~/.config/findmy-cli/aliases.json`.
+
+```bash
+findmy alias phone "Omar's iPhone"   # set
+findmy alias                         # list
+findmy alias --delete phone          # remove
+findmy ring phone --confirm          # any command that takes a device accepts one
+```
+
+`findmy phone` is the shorthand: with no argument it rings whatever the `phone`
+alias points at.
+
+```bash
+findmy phone --confirm
+```
+
 ```
 
 Successful `findmy people`, `findmy devices`, and `findmy items` runs append parsed sidebar

--- a/cmd/findmy/main.go
+++ b/cmd/findmy/main.go
@@ -39,6 +39,12 @@ func main() {
 		runWatch(os.Args[2:])
 	case "log":
 		runLog(os.Args[2:])
+	case "ring":
+		runRing(os.Args[2:])
+	case "phone":
+		runPhone(os.Args[2:])
+	case "alias":
+		runAlias(os.Args[2:])
 	case "-h", "--help", "help":
 		usage()
 	default:
@@ -59,6 +65,9 @@ Usage:
   findmy item    <name> [--json] [--keep]
   findmy watch   <people|devices|items> [--interval=5m] [--diff] [--json] [--once]
   findmy log     <name> [--kind=people|devices|items] [--since=DURATION] [--until=DURATION] [--limit=N] [--json]
+  findmy ring    <device|alias> [--confirm]
+  findmy phone   [device|alias] [--confirm]        (defaults to the "phone" alias)
+  findmy alias   [<name> <device> | --delete <name>]
 
 Flags:
   --json           emit JSON instead of a human table
@@ -67,15 +76,17 @@ Flags:
   --zoom           click matched row and OCR the detail pane
   --interval=DUR   watch polling interval (default 5m)
   --diff           watch: emit only changed rows (default on for --json, off for human)
-  --once           watch: poll once and exit`)
+  --once           watch: poll once and exit
+  --confirm        ring: actually play the sound (without it, dry run)`)
 	os.Exit(2)
 }
 
 type runOpts struct {
-	json  bool
-	keep  bool
-	zoom  bool
-	noLog bool
+	json    bool
+	keep    bool
+	zoom    bool
+	noLog   bool
+	confirm bool
 }
 
 // parseOpts splits args into known flags and positional args. Go's flag
@@ -95,6 +106,8 @@ func parseOpts(args []string) (runOpts, []string) {
 			o.noLog = true
 		case "--zoom", "-zoom":
 			o.zoom = true
+		case "--confirm", "-confirm":
+			o.confirm = true
 		default:
 			positional = append(positional, a)
 		}
@@ -897,6 +910,128 @@ func cleanup(path string, keep bool) {
 	if !keep {
 		_ = os.Remove(path)
 	}
+}
+
+// ring locates a device by scrolling the sidebar and plays a sound on it.
+// Ringing is loud and happens on a device that may not be in the room, so it
+// is dry-run by default: without --confirm we find the button and report
+// where it is, but never click it.
+func ring(target string, opts runOpts) {
+	raw := strings.TrimSpace(target)
+	if raw == "" {
+		fmt.Fprintln(os.Stderr, "usage: findmy ring <device|alias> [--confirm]")
+		os.Exit(2)
+	}
+	resolved := findmy.ResolveAlias(raw)
+	if resolved != raw {
+		fmt.Fprintf(os.Stderr, "%s -> %s\n", raw, resolved)
+	}
+
+	if !opts.confirm {
+		fmt.Fprintln(os.Stderr, "Dry run: locating the Play Sound button without clicking it.")
+		fmt.Fprintln(os.Stderr, "Add --confirm to actually make the device play a sound.")
+	}
+
+	w, err := findmy.PrepareDevices()
+	must(err)
+
+	match, err := findmy.FindDeviceByScroll(w, resolved, tmpDir())
+	must(err)
+	fmt.Fprintf(os.Stderr, "Found: %s\n", match.Name)
+
+	err = findmy.RingDevice(w, match, tmpDir(), !opts.confirm)
+	_ = findmy.SwitchTab(findmy.GetAppStrings().PeopleTab)
+	findmy.RestoreUserSpace()
+	must(err)
+
+	if opts.confirm {
+		fmt.Printf("Ringing %s...\n", match.Name)
+	} else {
+		fmt.Println("Dry run complete. Add --confirm to ring.")
+	}
+}
+
+func runRing(args []string) {
+	opts, rest := parseOpts(args)
+	ring(strings.Join(rest, " "), opts)
+}
+
+// runPhone is the shorthand: `findmy phone` rings whatever the "phone" alias
+// points at, so the common case needs no device name.
+func runPhone(args []string) {
+	opts, rest := parseOpts(args)
+	target := strings.Join(rest, " ")
+	if strings.TrimSpace(target) == "" {
+		target = findmy.ResolveAlias("phone")
+		if target == "phone" {
+			fmt.Fprintln(os.Stderr, "no \"phone\" alias set. Run: findmy alias phone \"Omar's iPhone\"")
+			os.Exit(2)
+		}
+	}
+	ring(target, opts)
+}
+
+// runAlias manages the name shortcuts in ~/.config/findmy-cli/aliases.json.
+func runAlias(args []string) {
+	_, rest := parseOpts(args)
+	m := findmy.LoadAliases()
+
+	for i, a := range rest {
+		if a != "--delete" && a != "-delete" {
+			continue
+		}
+		if i+1 >= len(rest) {
+			fmt.Fprintln(os.Stderr, "usage: findmy alias --delete <name>")
+			os.Exit(2)
+		}
+		name := rest[i+1]
+		key := strings.ToLower(name)
+		found := false
+		for k := range m {
+			if strings.ToLower(k) == key {
+				delete(m, k)
+				found = true
+			}
+		}
+		if !found {
+			fmt.Fprintf(os.Stderr, "alias %q not found\n", name)
+			os.Exit(1)
+		}
+		must(findmy.SaveAliases(m))
+		fmt.Printf("deleted alias %q\n", name)
+		return
+	}
+
+	if len(rest) == 0 {
+		if len(m) == 0 {
+			fmt.Fprintln(os.Stderr, "no aliases set. Add one: findmy alias phone \"Omar's iPhone\"")
+			return
+		}
+		names := make([]string, 0, len(m))
+		for k := range m {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		for _, k := range names {
+			fmt.Printf("%s -> %s\n", k, m[k])
+		}
+		return
+	}
+
+	if len(rest) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: findmy alias <name> <device>")
+		os.Exit(2)
+	}
+	name := rest[0]
+	device := strings.Join(rest[1:], " ")
+	for k := range m {
+		if strings.EqualFold(k, name) {
+			delete(m, k)
+		}
+	}
+	m[name] = device
+	must(findmy.SaveAliases(m))
+	fmt.Printf("%s -> %s\n", name, device)
 }
 
 func must(err error) {

--- a/cmd/findmy/main.go
+++ b/cmd/findmy/main.go
@@ -916,7 +916,7 @@ func cleanup(path string, keep bool) {
 // Ringing is loud and happens on a device that may not be in the room, so it
 // is dry-run by default: without --confirm we find the button and report
 // where it is, but never click it.
-func ring(target string, opts runOpts) {
+func ring(target string, opts runOpts) error {
 	raw := strings.TrimSpace(target)
 	if raw == "" {
 		fmt.Fprintln(os.Stderr, "usage: findmy ring <device|alias> [--confirm]")
@@ -932,28 +932,43 @@ func ring(target string, opts runOpts) {
 		fmt.Fprintln(os.Stderr, "Add --confirm to actually make the device play a sound.")
 	}
 
+	// Take this before PrepareDevices, which activates Find My. Read it after
+	// and we would just record Find My and never hand the display back.
+	findmy.RememberFrontApp()
+	// Every path below leaves Find My frontmost and on the Devices tab, errors
+	// included. ring therefore returns its errors rather than calling must:
+	// must exits the process, and os.Exit does not run deferred functions.
+	defer func() {
+		_ = findmy.SwitchTab(findmy.GetAppStrings().PeopleTab)
+		findmy.RestoreUserSpace()
+	}()
+
 	w, err := findmy.PrepareDevices()
-	must(err)
+	if err != nil {
+		return err
+	}
 
 	match, err := findmy.FindDeviceByScroll(w, resolved, tmpDir())
-	must(err)
+	if err != nil {
+		return err
+	}
 	fmt.Fprintf(os.Stderr, "Found: %s\n", match.Name)
 
-	err = findmy.RingDevice(w, match, tmpDir(), !opts.confirm)
-	_ = findmy.SwitchTab(findmy.GetAppStrings().PeopleTab)
-	findmy.RestoreUserSpace()
-	must(err)
+	if err := findmy.RingDevice(w, match, tmpDir(), !opts.confirm); err != nil {
+		return err
+	}
 
 	if opts.confirm {
 		fmt.Printf("Ringing %s...\n", match.Name)
 	} else {
 		fmt.Println("Dry run complete. Add --confirm to ring.")
 	}
+	return nil
 }
 
 func runRing(args []string) {
 	opts, rest := parseOpts(args)
-	ring(strings.Join(rest, " "), opts)
+	must(ring(strings.Join(rest, " "), opts))
 }
 
 // runPhone is the shorthand: `findmy phone` rings whatever the "phone" alias
@@ -968,7 +983,7 @@ func runPhone(args []string) {
 			os.Exit(2)
 		}
 	}
-	ring(target, opts)
+	must(ring(target, opts))
 }
 
 // runAlias manages the name shortcuts in ~/.config/findmy-cli/aliases.json.

--- a/helpers/findmy-helper/main.swift
+++ b/helpers/findmy-helper/main.swift
@@ -125,6 +125,41 @@ struct Permissions: Encodable {
 // is unreliable for CLI binaries (TCC entries can be stale across rebuilds),
 // so when it reports false we exercise the permission via SCShareableContent —
 // the only definitive probe.
+func cmdScroll(_ args: [String]) {
+    guard args.count >= 3, let x = Double(args[0]), let y = Double(args[1]), let dy = Int32(args[2]) else {
+        die("usage: findmy-helper scroll <x> <y> <dy> (dy: negative=down, positive=up)")
+    }
+    let pt = CGPoint(x: x, y: y)
+    let src = CGEventSource(stateID: .hidSystemState)
+
+    // Move the pointer first: scroll events go to whatever is under it.
+    let move = CGEvent(mouseEventSource: src, mouseType: .mouseMoved, mouseCursorPosition: pt, mouseButton: .left)
+    move?.post(tap: .cghidEventTap)
+    usleep(100_000)
+
+    // Catalyst apps ignore discrete scroll-wheel events, so send a phased
+    // continuous gesture -- what a trackpad produces -- in several steps.
+    let pixelDy = Double(dy) * 30.0
+    let steps = 5
+    let stepDy = pixelDy / Double(steps)
+
+    for i in 0..<steps {
+        let scroll = CGEvent(scrollWheelEvent2Source: src, units: .pixel, wheelCount: 1, wheel1: Int32(stepDy), wheel2: 0, wheel3: 0)
+        // Phase: 1 = began, 2 = changed, 4 = ended.
+        if i == 0 {
+            scroll?.setIntegerValueField(.scrollWheelEventScrollPhase, value: 1)
+        } else if i == steps - 1 {
+            scroll?.setIntegerValueField(.scrollWheelEventScrollPhase, value: 4)
+        } else {
+            scroll?.setIntegerValueField(.scrollWheelEventScrollPhase, value: 2)
+        }
+        scroll?.setIntegerValueField(.scrollWheelEventIsContinuous, value: 1)
+        scroll?.post(tap: .cghidEventTap)
+        usleep(20_000)
+    }
+    print("{\"ok\":true}")
+}
+
 func cmdPermissions(_ args: [String]) {
     var screenRecording = CGPreflightScreenCaptureAccess()
     if !screenRecording {
@@ -146,13 +181,14 @@ func cmdPermissions(_ args: [String]) {
 
 let args = Array(CommandLine.arguments.dropFirst())
 guard let sub = args.first else {
-    die("usage: findmy-helper {window|ocr|click|permissions} ...")
+    die("usage: findmy-helper {window|ocr|click|scroll|permissions} ...")
 }
 let rest = Array(args.dropFirst())
 switch sub {
 case "window": cmdWindow(rest)
 case "ocr": cmdOCR(rest)
 case "click": cmdClick(rest)
+case "scroll": cmdScroll(rest)
 case "permissions": cmdPermissions(rest)
 default: die("unknown subcommand: \(sub)")
 }

--- a/internal/findmy/aliases.go
+++ b/internal/findmy/aliases.go
@@ -1,0 +1,50 @@
+package findmy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func aliasPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config", "findmy-cli", "aliases.json")
+}
+
+func LoadAliases() map[string]string {
+	data, err := os.ReadFile(aliasPath())
+	if err != nil {
+		return map[string]string{}
+	}
+	var m map[string]string
+	if json.Unmarshal(data, &m) != nil {
+		return map[string]string{}
+	}
+	return m
+}
+
+func SaveAliases(m map[string]string) error {
+	p := aliasPath()
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, data, 0o644)
+}
+
+// ResolveAlias returns the device name for a given alias (case-insensitive).
+// If no alias matches, returns the input unchanged.
+func ResolveAlias(input string) string {
+	m := LoadAliases()
+	key := strings.ToLower(strings.TrimSpace(input))
+	for k, v := range m {
+		if strings.ToLower(k) == key {
+			return v
+		}
+	}
+	return input
+}

--- a/internal/findmy/ring.go
+++ b/internal/findmy/ring.go
@@ -1,0 +1,267 @@
+package findmy
+
+import (
+	"fmt"
+	"image"
+	_ "image/png"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Ringing a device means driving the FindMy UI: find the row in the sidebar,
+// open its detail card on the map, and click "Play Sound". Every step is OCR
+// against a screenshot, so the code is written to retry rather than to assume.
+
+// Scroll posts a continuous trackpad-style scroll at a screen point. Catalyst
+// apps ignore discrete scroll-wheel events, so the helper sends phased pixel
+// events instead. Positive dy scrolls up, negative down.
+func Scroll(x, y, dy int) error {
+	_, err := runHelper("scroll", fmt.Sprintf("%d", x), fmt.Sprintf("%d", y), fmt.Sprintf("%d", dy))
+	return err
+}
+
+// DeviceHit is a device located by scrolling the sidebar: just the name and
+// where its row sits in the captured image, which is all RingDevice needs.
+type DeviceHit struct {
+	Name  string
+	NameX int
+	NameY int
+}
+
+// previousApp remembers who was frontmost before we activated FindMy, so a
+// ring can hand the display back instead of leaving FindMy in the user's face.
+var previousApp string
+
+func rememberFrontApp() string {
+	out, err := exec.Command("osascript", "-e",
+		`tell application "System Events" to get bundle identifier of first process whose frontmost is true`).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// RestoreUserSpace reactivates whatever was frontmost before the ring, which
+// also switches macOS back to that app's Space.
+func RestoreUserSpace() {
+	if previousApp == "" || previousApp == "com.apple.findmy" {
+		return
+	}
+	_ = exec.Command("osascript", "-e",
+		fmt.Sprintf(`tell application id %q to activate`, previousApp)).Run()
+}
+
+// imageScaleFor derives the backing scale from a captured image. Capture uses
+// `-o`, so the bitmap is exactly the window size times the scale.
+func imageScaleFor(w *Window, imagePath string) float64 {
+	scale := 2.0
+	f, err := os.Open(imagePath)
+	if err != nil {
+		return scale
+	}
+	defer f.Close()
+	cfg, _, err := image.DecodeConfig(f)
+	if err != nil || w.Width <= 0 {
+		return scale
+	}
+	if s := float64(cfg.Width) / float64(w.Width); s >= 1 {
+		return s
+	}
+	return scale
+}
+
+func captureAndOCR(w *Window, tmpDir string) ([]TextLine, error) {
+	shot := filepath.Join(tmpDir, "snap.png")
+	if err := Capture(w, shot); err != nil {
+		return nil, err
+	}
+	defer os.Remove(shot)
+	return OCR(shot)
+}
+
+// pollOCR captures and OCRs until match returns true or timeout elapses. It
+// exists so the caller can exit as soon as the button appears instead of
+// sleeping for the worst case on every attempt.
+func pollOCR(w *Window, tmpDir string, timeout, interval time.Duration, match func([]TextLine) bool) []TextLine {
+	deadline := time.Now().Add(timeout)
+	shot := filepath.Join(tmpDir, "poll.png")
+	for {
+		if err := Capture(w, shot); err != nil {
+			return nil
+		}
+		lines, err := OCR(shot)
+		_ = os.Remove(shot)
+		if err != nil {
+			return nil
+		}
+		if match(lines) {
+			return lines
+		}
+		if time.Now().After(deadline) {
+			return nil
+		}
+		time.Sleep(interval)
+	}
+}
+
+// playSoundLabels is the "Play Sound" button text in the languages FindMy
+// ships. The button carries no accessibility identifier we can read from a
+// screenshot, so the label is the only handle we have.
+var playSoundLabels = []string{
+	"play sound", "émettre un son", "emettre un son", "ton abspielen",
+	"sound abspielen", "reproducir sonido", "riproduci suono", "emitir som",
+	"geluid afspelen", "spela upp ljud", "afspil lyd", "spill av lyd",
+	"toista ääni", "odtwórz dźwięk", "přehrát zvuk", "hang lejátszása",
+	"ses çal", "воспроизвести звук", "サウンドを再生", "사운드 재생",
+	"播放声音", "播放聲音", "เล่นเสียง", "phát âm thanh",
+}
+
+func findPlaySoundButton(lines []TextLine) *TextLine {
+	for i := range lines {
+		lower := strings.ToLower(strings.TrimSpace(lines[i].Text))
+		if lower == "" {
+			continue
+		}
+		for _, label := range playSoundLabels {
+			if strings.Contains(lower, label) {
+				return &lines[i]
+			}
+		}
+	}
+	return nil
+}
+
+// FindDeviceByScroll scrolls the Devices sidebar from the top, OCRing each
+// frame, until a row contains target. The list is virtualized, so a device
+// below the fold is invisible to a single capture -- scrolling is the only
+// way to reach it.
+func FindDeviceByScroll(w *Window, target, tmpDir string) (*DeviceHit, error) {
+	targetLower := strings.ToLower(strings.TrimSpace(target))
+	if targetLower == "" {
+		return nil, fmt.Errorf("no device name given")
+	}
+
+	sidebarX := w.X + 170 // horizontal center of the sidebar, in points
+	sidebarY := w.Y + w.Height/2
+
+	for i := 0; i < 20; i++ {
+		_ = Scroll(sidebarX, sidebarY, 10)
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	shot := filepath.Join(tmpDir, "scroll-find.png")
+	for pass := 0; pass < 20; pass++ {
+		if err := Capture(w, shot); err != nil {
+			return nil, fmt.Errorf("capture: %w", err)
+		}
+		lines, err := OCR(shot)
+		_ = os.Remove(shot)
+		if err != nil {
+			return nil, fmt.Errorf("ocr: %w", err)
+		}
+
+		sidebarRightPx := int(340 * imageScaleFor(w, shot))
+		for _, l := range lines {
+			if l.X+l.Width/2 >= sidebarRightPx {
+				continue // detail pane, not the sidebar
+			}
+			txt := strings.TrimSpace(l.Text)
+			if strings.Contains(strings.ToLower(txt), targetLower) {
+				return &DeviceHit{Name: txt, NameX: l.X, NameY: l.Y}, nil
+			}
+		}
+
+		_ = Scroll(sidebarX, sidebarY, -5)
+		time.Sleep(400 * time.Millisecond)
+	}
+
+	return nil, fmt.Errorf("device %q not found after scrolling the whole list", target)
+}
+
+// RingDevice opens a device's detail card and clicks "Play Sound".
+//
+// The sequence is empirical, not documented: click the sidebar row, wait for
+// the map to settle, then double-click the map center to raise the pin popup
+// and its detail card. The double-click is retried with growing delays --
+// FindMy drops the second click while the map is still animating, and the
+// retry ladder is what took this from roughly half the attempts to nearly all
+// of them. With dryRun the button is located and reported but never clicked.
+func RingDevice(w *Window, device *DeviceHit, tmpDir string, dryRun bool) error {
+	if err := requirePermissions(true); err != nil {
+		return err
+	}
+
+	previousApp = rememberFrontApp()
+	_ = Activate()
+	// Catalyst only routes synthetic clicks to a frontmost process.
+	_ = exec.Command("osascript", "-e",
+		`tell application "System Events" to tell process "FindMy" to set frontmost to true`).Run()
+	time.Sleep(400 * time.Millisecond)
+
+	shot := filepath.Join(tmpDir, "ring-scale.png")
+	scale := 2.0
+	if err := Capture(w, shot); err == nil {
+		scale = imageScaleFor(w, shot)
+		_ = os.Remove(shot)
+	}
+
+	// Fast path: the card may already be open from a previous run.
+	if lines, err := captureAndOCR(w, tmpDir); err == nil {
+		if btn := findPlaySoundButton(lines); btn != nil {
+			return clickOrDryRun(w, btn, scale, dryRun)
+		}
+	}
+
+	screenX := w.X + int(float64(device.NameX)/scale)
+	screenY := w.Y + int(float64(device.NameY)/scale) + 8
+	if err := Click(screenX, screenY); err != nil {
+		return fmt.Errorf("click device row: %w", err)
+	}
+
+	// Fixed wait: the map zoom animation has no completion signal we can read.
+	time.Sleep(3 * time.Second)
+
+	const sidebarPts = 340
+	mapCenterX := w.X + sidebarPts + (w.Width-sidebarPts)/2
+	mapCenterY := w.Y + w.Height/2
+
+	var button *TextLine
+	for attempt := 0; attempt < 5; attempt++ {
+		_ = Click(mapCenterX, mapCenterY)
+		time.Sleep(time.Duration(1000+attempt*200) * time.Millisecond)
+		_ = Click(mapCenterX, mapCenterY)
+
+		lines := pollOCR(w, tmpDir,
+			time.Duration(2000+attempt*500)*time.Millisecond,
+			300*time.Millisecond,
+			func(lines []TextLine) bool { return findPlaySoundButton(lines) != nil })
+		if lines != nil {
+			button = findPlaySoundButton(lines)
+			break
+		}
+	}
+
+	if button == nil {
+		return fmt.Errorf("'Play Sound' button not found -- the device may be offline, or its map pin was not clickable")
+	}
+	return clickOrDryRun(w, button, scale, dryRun)
+}
+
+// clickOrDryRun clicks the button, or reports where it would have clicked.
+// The tappable icon sits above its label, hence the upward offset.
+func clickOrDryRun(w *Window, btn *TextLine, scale float64, dryRun bool) error {
+	btnX := w.X + int(float64(btn.X+btn.Width/2)/scale)
+	btnY := w.Y + int(float64(btn.Y)/scale) - int(20/scale)
+	if dryRun {
+		fmt.Fprintf(os.Stderr, "dry-run: would click %q at screen (%d, %d)\n",
+			strings.TrimSpace(btn.Text), btnX, btnY)
+		return nil
+	}
+	if err := Click(btnX, btnY); err != nil {
+		return fmt.Errorf("click play sound: %w", err)
+	}
+	return nil
+}

--- a/internal/findmy/ring.go
+++ b/internal/findmy/ring.go
@@ -35,13 +35,18 @@ type DeviceHit struct {
 // ring can hand the display back instead of leaving FindMy in the user's face.
 var previousApp string
 
-func rememberFrontApp() string {
+// RememberFrontApp records the frontmost app so RestoreUserSpace can return to
+// it. It must be called BEFORE anything activates Find My -- PrepareDevices
+// already does, and reading it afterwards just records Find My itself, which
+// makes the restore a silent no-op.
+func RememberFrontApp() {
 	out, err := exec.Command("osascript", "-e",
 		`tell application "System Events" to get bundle identifier of first process whose frontmost is true`).Output()
 	if err != nil {
-		return ""
+		previousApp = ""
+		return
 	}
-	return strings.TrimSpace(string(out))
+	previousApp = strings.TrimSpace(string(out))
 }
 
 // RestoreUserSpace reactivates whatever was frontmost before the ring, which
@@ -134,13 +139,42 @@ func findPlaySoundButton(lines []TextLine) *TextLine {
 	return nil
 }
 
+// matchSidebarDevice picks the row for target out of one OCR frame. An exact
+// name wins over a substring anywhere in the frame: "Omar's iPhone" and
+// "Omar's iPhone 15" both contain the former, and ringing whichever happens to
+// sit higher in the sidebar is not a coin flip worth taking.
+func matchSidebarDevice(lines []TextLine, target string, sidebarRightPx int) *DeviceHit {
+	targetLower := strings.ToLower(strings.TrimSpace(target))
+	if targetLower == "" {
+		return nil
+	}
+	var partial *DeviceHit
+	for _, l := range lines {
+		if l.X+l.Width/2 >= sidebarRightPx {
+			continue // detail pane, not the sidebar
+		}
+		txt := strings.TrimSpace(l.Text)
+		if txt == "" {
+			continue
+		}
+		lower := strings.ToLower(txt)
+		hit := &DeviceHit{Name: txt, NameX: l.X, NameY: l.Y}
+		if lower == targetLower {
+			return hit
+		}
+		if partial == nil && strings.Contains(lower, targetLower) {
+			partial = hit
+		}
+	}
+	return partial
+}
+
 // FindDeviceByScroll scrolls the Devices sidebar from the top, OCRing each
-// frame, until a row contains target. The list is virtualized, so a device
+// frame, until a row matches target. The list is virtualized, so a device
 // below the fold is invisible to a single capture -- scrolling is the only
 // way to reach it.
 func FindDeviceByScroll(w *Window, target, tmpDir string) (*DeviceHit, error) {
-	targetLower := strings.ToLower(strings.TrimSpace(target))
-	if targetLower == "" {
+	if strings.TrimSpace(target) == "" {
 		return nil, fmt.Errorf("no device name given")
 	}
 
@@ -153,9 +187,15 @@ func FindDeviceByScroll(w *Window, target, tmpDir string) (*DeviceHit, error) {
 	time.Sleep(500 * time.Millisecond)
 
 	shot := filepath.Join(tmpDir, "scroll-find.png")
+	scale := 0.0
 	for pass := 0; pass < 20; pass++ {
 		if err := Capture(w, shot); err != nil {
 			return nil, fmt.Errorf("capture: %w", err)
+		}
+		// Read the scale off the file while it still exists; OCR and removal
+		// both come after.
+		if scale == 0 {
+			scale = imageScaleFor(w, shot)
 		}
 		lines, err := OCR(shot)
 		_ = os.Remove(shot)
@@ -163,15 +203,8 @@ func FindDeviceByScroll(w *Window, target, tmpDir string) (*DeviceHit, error) {
 			return nil, fmt.Errorf("ocr: %w", err)
 		}
 
-		sidebarRightPx := int(340 * imageScaleFor(w, shot))
-		for _, l := range lines {
-			if l.X+l.Width/2 >= sidebarRightPx {
-				continue // detail pane, not the sidebar
-			}
-			txt := strings.TrimSpace(l.Text)
-			if strings.Contains(strings.ToLower(txt), targetLower) {
-				return &DeviceHit{Name: txt, NameX: l.X, NameY: l.Y}, nil
-			}
+		if hit := matchSidebarDevice(lines, target, int(340*scale)); hit != nil {
+			return hit, nil
 		}
 
 		_ = Scroll(sidebarX, sidebarY, -5)
@@ -194,7 +227,6 @@ func RingDevice(w *Window, device *DeviceHit, tmpDir string, dryRun bool) error 
 		return err
 	}
 
-	previousApp = rememberFrontApp()
 	_ = Activate()
 	// Catalyst only routes synthetic clicks to a frontmost process.
 	_ = exec.Command("osascript", "-e",
@@ -208,9 +240,11 @@ func RingDevice(w *Window, device *DeviceHit, tmpDir string, dryRun bool) error 
 		_ = os.Remove(shot)
 	}
 
-	// Fast path: the card may already be open from a previous run.
+	// Fast path: the card may already be open from a previous run -- but only
+	// if it is THIS device's card. A card left open for another device shows
+	// its own Play Sound button, and clicking that rings the wrong thing.
 	if lines, err := captureAndOCR(w, tmpDir); err == nil {
-		if btn := findPlaySoundButton(lines); btn != nil {
+		if btn := findPlaySoundButton(lines); btn != nil && cardShowsDevice(lines, device.Name, int(340*scale)) {
 			return clickOrDryRun(w, btn, scale, dryRun)
 		}
 	}
@@ -248,6 +282,26 @@ func RingDevice(w *Window, device *DeviceHit, tmpDir string, dryRun bool) error 
 		return fmt.Errorf("'Play Sound' button not found -- the device may be offline, or its map pin was not clickable")
 	}
 	return clickOrDryRun(w, button, scale, dryRun)
+}
+
+// cardShowsDevice reports whether the open detail card names this device. The
+// card renders to the right of the sidebar, so sidebar rows -- which always
+// include the requested name once we have scrolled to it -- must not count as
+// proof that the card itself belongs to that device.
+func cardShowsDevice(lines []TextLine, name string, sidebarRightPx int) bool {
+	want := strings.ToLower(strings.TrimSpace(name))
+	if want == "" {
+		return false
+	}
+	for _, l := range lines {
+		if l.X < sidebarRightPx {
+			continue // sidebar, not the card
+		}
+		if strings.Contains(strings.ToLower(strings.TrimSpace(l.Text)), want) {
+			return true
+		}
+	}
+	return false
 }
 
 // clickOrDryRun clicks the button, or reports where it would have clicked.

--- a/internal/findmy/ring_test.go
+++ b/internal/findmy/ring_test.go
@@ -1,0 +1,97 @@
+package findmy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindPlaySoundButtonMatchesLocalizedLabels(t *testing.T) {
+	for _, label := range []string{"Play Sound", "Émettre un son", "Ton abspielen", "サウンドを再生"} {
+		lines := []TextLine{
+			{Text: "Omar's iPhone"},
+			{Text: label, X: 100, Y: 400, Width: 80},
+		}
+		got := findPlaySoundButton(lines)
+		if got == nil {
+			t.Fatalf("label %q not matched", label)
+		}
+		if got.Text != label {
+			t.Fatalf("matched %q, want %q", got.Text, label)
+		}
+	}
+}
+
+func TestFindPlaySoundButtonIgnoresUnrelatedText(t *testing.T) {
+	lines := []TextLine{{Text: "Directions"}, {Text: "Notify When Found"}, {Text: ""}}
+	if got := findPlaySoundButton(lines); got != nil {
+		t.Fatalf("matched %q, want no match", got.Text)
+	}
+}
+
+// The button label is OCR'd, so it arrives with whatever case and padding the
+// renderer produced.
+func TestFindPlaySoundButtonToleratesCaseAndPadding(t *testing.T) {
+	lines := []TextLine{{Text: "  PLAY SOUND  "}}
+	if findPlaySoundButton(lines) == nil {
+		t.Fatal("uppercase padded label not matched")
+	}
+}
+
+func TestImageScaleForFallsBackWhenImageMissing(t *testing.T) {
+	w := &Window{Width: 1024}
+	if got := imageScaleFor(w, filepath.Join(t.TempDir(), "nope.png")); got != 2.0 {
+		t.Fatalf("got %v, want 2.0", got)
+	}
+}
+
+func TestAliasesRoundTripAndResolveCaseInsensitively(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if got := LoadAliases(); len(got) != 0 {
+		t.Fatalf("expected no aliases in a fresh home, got %v", got)
+	}
+	if got := ResolveAlias("phone"); got != "phone" {
+		t.Fatalf("unknown alias should pass through, got %q", got)
+	}
+
+	if err := SaveAliases(map[string]string{"Phone": "Omar's iPhone"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := ResolveAlias("PHONE"); got != "Omar's iPhone" {
+		t.Fatalf("got %q, want the mapped device", got)
+	}
+	if got := ResolveAlias("  phone  "); got != "Omar's iPhone" {
+		t.Fatalf("padded input got %q", got)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".config", "findmy-cli", "aliases.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("aliases file is not valid JSON: %v", err)
+	}
+	if m["Phone"] != "Omar's iPhone" {
+		t.Fatalf("on disk: %v", m)
+	}
+}
+
+// A corrupt file must not take the CLI down; every command resolves aliases.
+func TestLoadAliasesSurvivesCorruptFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".config", "findmy-cli")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "aliases.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := LoadAliases(); len(got) != 0 {
+		t.Fatalf("got %v, want an empty map", got)
+	}
+}

--- a/internal/findmy/ring_test.go
+++ b/internal/findmy/ring_test.go
@@ -95,3 +95,62 @@ func TestLoadAliasesSurvivesCorruptFile(t *testing.T) {
 		t.Fatalf("got %v, want an empty map", got)
 	}
 }
+
+func TestMatchSidebarDevicePrefersExactOverSubstring(t *testing.T) {
+	// "Omar's iPhone 15" sits above the exact match; the exact one must win.
+	lines := []TextLine{
+		{Text: "Omar's iPhone 15", X: 60, Y: 100, Width: 200},
+		{Text: "Omar's iPhone", X: 60, Y: 200, Width: 180},
+	}
+	got := matchSidebarDevice(lines, "Omar's iPhone", 680)
+	if got == nil || got.Name != "Omar's iPhone" || got.NameY != 200 {
+		t.Fatalf("got %+v, want the exact row at y=200", got)
+	}
+}
+
+func TestMatchSidebarDeviceFallsBackToSubstring(t *testing.T) {
+	lines := []TextLine{{Text: "Omar's iPhone 15", X: 60, Y: 100, Width: 200}}
+	got := matchSidebarDevice(lines, "iphone", 680)
+	if got == nil || got.Name != "Omar's iPhone 15" {
+		t.Fatalf("got %+v, want the substring row", got)
+	}
+}
+
+func TestMatchSidebarDeviceIgnoresDetailPane(t *testing.T) {
+	// Same name, but rendered in the card to the right of the sidebar.
+	lines := []TextLine{{Text: "Omar's iPhone", X: 900, Y: 100, Width: 180}}
+	if got := matchSidebarDevice(lines, "Omar's iPhone", 680); got != nil {
+		t.Fatalf("got %+v, want no sidebar match", got)
+	}
+}
+
+func TestMatchSidebarDeviceEmptyTargets(t *testing.T) {
+	lines := []TextLine{{Text: "Omar's iPhone", X: 60, Width: 180}}
+	if got := matchSidebarDevice(lines, "   ", 680); got != nil {
+		t.Fatalf("got %+v, want nil for a blank target", got)
+	}
+}
+
+func TestCardShowsDeviceRequiresTheCardNotTheSidebar(t *testing.T) {
+	sidebarOnly := []TextLine{{Text: "Omar's iPhone", X: 60, Width: 180}}
+	if cardShowsDevice(sidebarOnly, "Omar's iPhone", 680) {
+		t.Fatal("a sidebar row must not count as the card being open")
+	}
+
+	cardOpen := []TextLine{
+		{Text: "Omar's iPhone", X: 60, Width: 180},
+		{Text: "Omar's iPhone", X: 900, Width: 180},
+	}
+	if !cardShowsDevice(cardOpen, "Omar's iPhone", 680) {
+		t.Fatal("card text to the right of the sidebar should count")
+	}
+}
+
+// The fast path exists to skip re-navigation. It must not fire when the open
+// card belongs to a different device, or a ring lands on the wrong one.
+func TestCardShowsDeviceRejectsAnotherDevicesCard(t *testing.T) {
+	lines := []TextLine{{Text: "Sarah's iPad", X: 900, Width: 160}, {Text: "Play Sound", X: 950}}
+	if cardShowsDevice(lines, "Omar's iPhone", 680) {
+		t.Fatal("another device's open card must not satisfy the fast path")
+	}
+}


### PR DESCRIPTION
Resurrects the two features from `feat/locale-support` (May 15) that never reached main. Main has since re-implemented that branch's locale, zoom and Space handling independently, so a merge conflicts in five files including an add/add on `locale.go`. These are ported fresh against today's code instead.

## `findmy ring <device|alias> [--confirm]`

Scrolls the Devices sidebar until it OCRs the target row, clicks it, double-clicks the map to raise the pin's detail card, and clicks **Play Sound**. Nothing in that sequence reports completion, so every step retries: the double-click runs up to five times with growing delays, and the button is polled for rather than slept on. That ladder is the original branch's reliability work, kept as-is.

**Dry run unless you pass `--confirm`.** The original had `phone` ring immediately while `ring` was gated, so the safety depended on which name you typed. Here both go through the same gate, and `phone` is just the shorthand that defaults to the `phone` alias.

## Aliases

`~/.config/findmy-cli/aliases.json`, resolved case-insensitively:

```bash
findmy alias phone "Omar's iPhone"
findmy ring phone --confirm
findmy phone --confirm          # same thing
```

## Verification

Builds, `go vet` clean, 9 new tests pass (localized button labels, scale fallback, alias round-trip, and a corrupt `aliases.json` — which must never take the CLI down, since every command resolves aliases). The Swift helper compiles and advertises its new `scroll` subcommand. The alias surface is exercised end to end against a temp HOME: set, list, case-insensitive overwrite, delete, and both usage errors.

**The ring path is not verified end-to-end.** It drives the Find My UI, and verifying it means audibly ringing a device. Dry-run it with `findmy ring "<device>"` (no `--confirm`) — it will locate the button and print the coordinates it would have clicked.

## Not ported

The branch's BetterDisplay virtual-display mode (depends on a third-party app) and six benchmark/optimization shell scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdvrUy3dukjMh6GNaUC9iq